### PR TITLE
Person View Example and refactor of many things

### DIFF
--- a/packages/admin/src/app/feature/project-management/all-people/people.store.ts
+++ b/packages/admin/src/app/feature/project-management/all-people/people.store.ts
@@ -14,7 +14,7 @@ import {
 import { PersonService } from '@shared/services/person.service';
 import { inject } from '@angular/core';
 import { PersonModel } from '@shared/models/person.model';
-import { lastValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { PageEvent } from '@angular/material/paginator';
 
 interface PersonState {
@@ -41,7 +41,7 @@ export const PeopleStore = signalStore(
     async load(limit: number, offset: number) {
       patchState(store, setPending());
       const resp: { data: PersonModel[]; meta: { count: number } } =
-        await lastValueFrom(personService.getAllPeople(limit, offset));
+        await firstValueFrom(personService.getAllPeople(limit, offset));
       patchState(
         store,
         { people: resp.data, totalData: resp.meta.count },
@@ -60,7 +60,7 @@ export const PeopleStore = signalStore(
         setPending(),
       );
       const resp: { data: PersonModel[]; meta: { count: number } } =
-        await lastValueFrom(
+        await firstValueFrom(
           personService.getAllPeople(store.limit(), store.offset()),
         );
       patchState(

--- a/packages/admin/src/app/feature/project-management/person/person.component.html
+++ b/packages/admin/src/app/feature/project-management/person/person.component.html
@@ -1,5 +1,24 @@
-@if (personStore.isFulfilled()) {
+@if (personStore.isReady()) {
   <form [formGroup]="personForm">
+    <div class="edit-button-container">
+      <button
+        mat-flat-button
+        type="button"
+        (click)="personStore.toggleEditMode()"
+        class="default-button"
+        [disabled]="personStore.inEditMode()"
+      >
+        Edit
+      </button>
+    </div>
+
+    @if (personStore.isErrored()) {
+      <div>
+        @for (error of personStore.errors(); track error.title) {
+          <h3 class="error-text">Error: {{ error.title }}</h3>
+        }
+      </div>
+    }
     <mat-form-field class="example-full-width">
       <mat-label>Family Name</mat-label>
       <input matInput placeholder="Name" formControlName="familyName" />
@@ -37,11 +56,24 @@
       }
     </mat-form-field>
 
-    <div class="button-container">
-      <button mat-button type="reset" class="default-form-clear-button">
-        Clear
+    <div class="form-button-container">
+      <button
+        mat-button
+        type="button"
+        (click)="personStore.toggleEditMode()"
+        class="default-button"
+        [disabled]="!personStore.inEditMode()"
+      >
+        Cancel
       </button>
-      <button mat-flat-button type="submit" class="default-form-submit-button">
+      <button
+        mat-flat-button
+        type="submit"
+        class="default-button"
+        [disabled]="
+          !personStore.inEditMode() || !personForm.valid || !personForm.dirty
+        "
+      >
         Save
       </button>
     </div>

--- a/packages/admin/src/app/feature/project-management/person/person.component.scss
+++ b/packages/admin/src/app/feature/project-management/person/person.component.scss
@@ -1,3 +1,7 @@
+@use 'colors' as colors;
+
+// TODO: Move any of this to a mix-in when complete
+
 form {
   display: flex;
   flex-direction: column;
@@ -10,10 +14,22 @@ form {
     margin-bottom: 16px;
   }
 
-  .button-container {
+  .form-button-container {
     display: flex;
     justify-content: space-between;
     width: 100%;
     margin-top: 16px;
   }
+
+  .edit-button-container {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    margin-top: 16px;
+    margin-bottom: 24px;
+  }
+}
+
+.error-text {
+  color: colors.$error;
 }

--- a/packages/admin/src/app/feature/project-management/person/person.component.ts
+++ b/packages/admin/src/app/feature/project-management/person/person.component.ts
@@ -1,12 +1,10 @@
-import { Component, inject, Input, input, OnInit } from '@angular/core';
+import { Component, effect, inject, Input, OnInit } from '@angular/core';
 import {
+  ControlEvent,
   FormControl,
   FormGroup,
-  FormResetEvent,
   FormSubmittedEvent,
-  PristineChangeEvent,
   ReactiveFormsModule,
-  TouchedChangeEvent,
   Validators,
   ValueChangeEvent,
 } from '@angular/forms';
@@ -59,9 +57,19 @@ export class PersonComponent implements OnInit {
     ),
   });
 
+  constructor() {
+    effect(() => {
+      if (this.personStore.inEditMode()) {
+        this.personForm.enable();
+      } else {
+        this.personForm.disable();
+      }
+    });
+  }
+
   ngOnInit(): void {
     if (this.personId) {
-      this.personStore.load(this.personId).then(resp => {
+      this.personStore.initialize(this.personId).then(() => {
         this.personForm.patchValue({
           familyName: this.personStore.person()?.familyName,
           givenName: this.personStore.person()?.givenName,
@@ -71,17 +79,10 @@ export class PersonComponent implements OnInit {
     }
 
     this.personForm.events.subscribe(event => {
-      if (event instanceof FormSubmittedEvent) {
-        console.log('Form: Submitted changed=', event);
-      } else if (event instanceof FormResetEvent) {
-        console.log('Form: Reset', event);
-      } else if (event instanceof TouchedChangeEvent) {
-        console.log('TouchedChangeEvent', event.touched);
-      } else if (event instanceof PristineChangeEvent) {
-        console.log('PristineChangeEvent', event.pristine);
+      if ((event as ControlEvent) instanceof FormSubmittedEvent) {
+        this.personStore.update(this.personForm.value);
       } else if (event instanceof ValueChangeEvent) {
-        console.log('familyName changed=', event.value.familyName);
-        console.log('givenName changed=', event.value.givenName);
+        // This is here for an example.  Also, there are other events that can be caught
       }
     });
   }

--- a/packages/admin/src/app/shared/helpers/error-response-formatter.helper.ts
+++ b/packages/admin/src/app/shared/helpers/error-response-formatter.helper.ts
@@ -1,0 +1,21 @@
+import { Observable, of, throwError } from 'rxjs';
+import { ErrorResponseType } from '@shared/schemas/error.schema';
+import { ZodError } from 'zod';
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * Formats Zod validation and HttpErrorResponse errors into standard response.  Throws an excpetion if format is not recognized.
+ * @returns Observable<ErrorResponseType>
+ * @param error
+ */
+export function defaultErrorResponseHandler(
+  error: any,
+): Observable<ErrorResponseType> {
+  if (error instanceof ZodError) {
+    return of({ errors: error.errors });
+  } else if (error instanceof HttpErrorResponse) {
+    return of({ errors: error.error.errors });
+  } else {
+    return throwError(() => error); // Error type is unhandled, best to blow things up
+  }
+}

--- a/packages/admin/src/app/shared/models/person.model.ts
+++ b/packages/admin/src/app/shared/models/person.model.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { PersonType } from '@shared/schemas/person.schema';
+import { PersonUpdateType } from '@shared/schemas/person.schema';
 import { PersonTypeModel } from '@shared/models/person-type.model';
 
 // Base interface with common properties
@@ -34,7 +34,7 @@ export class PersonModel {
   public updatedAt: DateTime;
   public personType?: PersonTypeModel;
 
-  constructor(data: PersonType) {
+  constructor(data: PersonUpdateType) {
     this.id = data.id;
     this.familyName = data.familyName;
     this.givenName = data.givenName;

--- a/packages/admin/src/app/shared/schemas/error.schema.ts
+++ b/packages/admin/src/app/shared/schemas/error.schema.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
-import { UserSchema } from '@shared/schemas/user.schema';
 
-export const ErrorSchema = UserSchema.extend({
-  title: z.string(),
-  code: z.string().optional(),
-  detail: z.string().optional(),
-  meta: z.array(z.any()).optional(),
-}).strict();
+export const ErrorSchema = z
+  .object({
+    title: z.string(),
+    code: z.string().optional(),
+    detail: z.string().optional(),
+    meta: z.array(z.any()).optional(),
+  })
+  .strict();
 
 const ErrorsSchema: any = z.object({
   errors: z.array(ErrorSchema),

--- a/packages/admin/src/app/shared/schemas/person.schema.ts
+++ b/packages/admin/src/app/shared/schemas/person.schema.ts
@@ -9,7 +9,7 @@ export const PersonSchema: any = z
     givenName: z.string(),
     personTypeId: z.string().uuid().optional(),
     tags: z.array(z.any()).optional(),
-    user: z.any().optional(), //TODO: this should be UserSchema.optional() but throws error
+    user: z.lazy(() => UserSchema.optional().nullable()),
     personType: z.any().optional(), //TODO: Need to create personType schema
     createdAt: z.string().datetime({ offset: true }),
     updatedAt: z.string().datetime({ offset: true }),
@@ -23,6 +23,8 @@ export const PersonUpdateSchema = PersonSchema.extend({
   givenName: z.string().optional(),
   personTypeId: z.string().uuid().optional(),
   tags: z.array(z.any()).optional(),
+  createdAt: z.string().datetime({ offset: true }).optional(),
+  updatedAt: z.string().datetime({ offset: true }).optional(),
 }).strict();
 
 //  Multiple People

--- a/packages/admin/src/app/shared/schemas/user.schema.ts
+++ b/packages/admin/src/app/shared/schemas/user.schema.ts
@@ -15,6 +15,7 @@ export const UserSchema = z
     updatedAt: z.string().datetime({ offset: true }),
     role: RoleSchema.optional(),
     person: PersonSchema.optional(),
+    tags: z.array(z.any()).optional(),
   })
   .strict();
 

--- a/packages/admin/src/app/shared/store/request-status.feature.ts
+++ b/packages/admin/src/app/shared/store/request-status.feature.ts
@@ -1,37 +1,36 @@
 import { computed } from '@angular/core';
 import { signalStoreFeature, withComputed, withState } from '@ngrx/signals';
+import { ErrorResponseType } from '@shared/schemas/error.schema';
 
-export type RequestStatus =
-  | 'idle'
-  | 'pending'
-  | 'fulfilled'
-  | { error: string };
+export type RequestStatus = 'idle' | 'pending' | 'fulfilled' | 'errored';
 export interface RequestStatusState {
   requestStatus: RequestStatus;
+  errors: ErrorResponseType[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function withRequestStatus<_>() {
   return signalStoreFeature(
-    withState<RequestStatusState>({ requestStatus: 'idle' }),
+    withState<RequestStatusState>({
+      requestStatus: 'idle',
+      errors: [],
+    }),
     withComputed(({ requestStatus }) => ({
       isPending: computed(() => requestStatus() === 'pending'),
       isFulfilled: computed(() => requestStatus() === 'fulfilled'),
-      error: computed(() => {
-        const status = requestStatus();
-        return typeof status === 'object' ? status.error : null;
-      }),
+      isErrored: computed(() => requestStatus() === 'errored'),
     })),
   );
 }
 
 export function setPending(): RequestStatusState {
-  return { requestStatus: 'pending' };
+  return { requestStatus: 'pending', errors: [] };
 }
 
 export function setFulfilled(): RequestStatusState {
-  return { requestStatus: 'fulfilled' };
+  return { requestStatus: 'fulfilled', errors: [] };
 }
 
-export function setError(error: string): RequestStatusState {
-  return { requestStatus: { error } };
+export function setErrors(errors: ErrorResponseType[]): RequestStatusState {
+  return { requestStatus: 'errored', errors: errors };
 }

--- a/packages/admin/src/app/styles/mixins/_button.scss
+++ b/packages/admin/src/app/styles/mixins/_button.scss
@@ -23,13 +23,7 @@
     border-radius: 0;
   }
 
-  .default-form-submit-button {
-    width: auto;
-    min-width: 200px;
-    border-radius: 0;
-  }
-
-  .default-form-clear-button {
+  .default-button {
     width: auto;
     min-width: 200px;
     border-radius: 0;

--- a/packages/server/app/controllers/people_controller.ts
+++ b/packages/server/app/controllers/people_controller.ts
@@ -16,11 +16,15 @@ export default class PeopleController {
 
     let countQuery = db.from('people')
 
-    let query = Person.query().preload('user').preload('personType')
+    let query = Person.query()
+      .orderBy('familyName', 'asc')
+      .orderBy('givenName', 'asc')
+      .preload('user')
+      .preload('personType')
 
     if (personTypeId) {
       query.where('personTypeId', personTypeId)
-      // DB contex use sql column names
+      // DB context use sql column names
       countQuery.where('person_type_id', personTypeId)
     }
     if (limit) {
@@ -71,7 +75,7 @@ export default class PeopleController {
     await auth.authenticate()
     await request.validateUsing(updatePersonValidator)
     await paramsUUIDValidator.validate(params)
-    const cleanRequest = request.only(['givenName', 'familyName'])
+    const cleanRequest = request.only(['givenName', 'familyName', 'personTypeId', 'tags'])
     const person = await Person.findOrFail(params.id)
     const updatedPerson = await person.merge(cleanRequest).save()
     return { data: updatedPerson }

--- a/packages/server/app/controllers/person_types_controller.ts
+++ b/packages/server/app/controllers/person_types_controller.ts
@@ -1,4 +1,3 @@
-import { DbExceptionParser } from '#exceptions/db_execptions'
 import PersonType from '#models/person_type'
 import { paramsUUIDValidator } from '#validators/common'
 import { createPersonTypeValidator, updatePersonTypeValidator } from '#validators/person_type'

--- a/packages/server/config/cors.ts
+++ b/packages/server/config/cors.ts
@@ -9,7 +9,7 @@ import { defineConfig } from '@adonisjs/cors'
 const corsConfig = defineConfig({
   enabled: true,
   origin: true,
-  methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'],
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'],
   headers: true,
   exposeHeaders: [],
   credentials: true,

--- a/packages/server/database/factories/person_factory.ts
+++ b/packages/server/database/factories/person_factory.ts
@@ -6,7 +6,6 @@ export const PersonFactory = factory
     return {
       family_name: faker.person.lastName(),
       given_name: faker.person.firstName(),
-      tags: [],
     }
   })
   .build()


### PR DESCRIPTION
- Added button styles
- Added PATCH to CORS config
- ErrorSchema was incorrectly extending UserSchema
- Added an error response formatter helper
- Ordered the get people query by last, first name
- Added the person view (and partial edit (you can updated))
- Is showing the person type id, because person types aren't implemented yet
- Greatly simplified the person/people services
- Person/People services return the data/errors message format (with deserialized models).  This allows the components to handle the error messages as needed