### PR TITLE
Database and cache services should only restart if unstopped

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -57,7 +57,7 @@ services:
 
   db:
     image: postgres:16-bookworm
-    restart: always
+    restart: unless-stopped
     ports:
       - '5432:5432'
     environment:
@@ -72,7 +72,7 @@ services:
 
   redis:
     image: redis:7-bookworm
-    restart: always
+    restart: unless-stopped
     #command: redis-server --requirepass arcwell
     ports:
       - '6379:6379'


### PR DESCRIPTION
Change the `compose.yml` services definition for the backing db and redis services so their restart behavior is changed to "unless-stopped"

This corrects a local development behavior where restarting the Docker hypervisor/desktop service force-restarts these backing services. This can cause conflict on ports 5432 and 6379 for developers user other projects or cause confusion when attempting to start the Arcwell stack without knowing docker has force-restarted these services.

The new behavior of "unless-stopped" will only restart the services if they were running, crashed, hung, or otherwise were intended to still be running when the docker service closed.