### PR TITLE
feature/ARCWELL-222-get-current-user-with-token

### DIFF
--- a/packages/admin/src/app/app.component.ts
+++ b/packages/admin/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { FeaturesMenuComponent } from '@feature/project-management/features-menu/features-menu.component';
 import { FeatureSubMenuComponent } from '@feature/project-management/feature-sub-menu/feature-sub-menu.component';
 import { TopMenuComponent } from './feature/top-menu/top-menu.component';
+import { AuthStore } from './shared/store/auth.store';
 
 @Component({
   selector: 'aw-app-root',
@@ -24,6 +25,7 @@ export class AppComponent {
   title = 'Arcwell';
   private matIconRegistry = inject(MatIconRegistry);
   private domSanitizer = inject(DomSanitizer);
+  readonly authStore = inject(AuthStore);
 
   constructor() {
     this.matIconRegistry.addSvgIcon(
@@ -32,5 +34,9 @@ export class AppComponent {
         'assets/arcwell-logo.svg',
       ),
     );
+
+    if (!this.authStore.currentUser() && this.authStore.token()) {
+      this.authStore.loadCurrentUser();
+    }
   }
 }

--- a/packages/admin/src/app/feature/project-management/project-management.component.ts
+++ b/packages/admin/src/app/feature/project-management/project-management.component.ts
@@ -25,14 +25,6 @@ export class ProjectManagementComponent implements AfterViewInit {
   private router = inject(Router);
   readonly featureStore = inject(FeatureStore);
 
-  constructor() {
-    effect(() => {
-      if (!this.authStore.currentUser()) {
-        this.router.navigate(['auth', 'login']);
-      }
-    });
-  }
-
   ngAfterViewInit() {
     if (this.authStore.currentUser()) {
       this.featureStore.load();

--- a/packages/admin/src/app/shared/data-access/auth.service.ts
+++ b/packages/admin/src/app/shared/data-access/auth.service.ts
@@ -3,7 +3,7 @@ import { catchError, map, Observable, tap } from 'rxjs';
 import { Credentials } from '@shared/interfaces/credentials';
 import { HttpClient } from '@angular/common/http';
 import { UserModel } from '@shared/models/user.model';
-import { deserializeUser } from '@shared/schemas/user.schema';
+import { UserResponseType, deserializeUser } from '@shared/schemas/user.schema';
 import { ErrorResponseType } from '@shared/schemas/error.schema';
 import {
   LoginResponseSchema,
@@ -55,5 +55,13 @@ export class AuthService {
           return defaultErrorResponseHandler(error);
         }),
       );
+  }
+
+  me(): Observable<UserResponseType | ErrorResponseType> {
+    return this.http.get<UserResponseType>(`${this.apiUrl}/auth/me`).pipe(
+      map(response => {
+        return deserializeUser(response.data);
+      }),
+    );
   }
 }

--- a/packages/admin/src/app/shared/store/auth.store.ts
+++ b/packages/admin/src/app/shared/store/auth.store.ts
@@ -82,19 +82,15 @@ export const AuthStore = signalStore(
     async clearStore() {
       patchState(store, initialState);
     },
-  })),
-  withHooks({
-    onInit(store) {
-      effect(() => {
-        // 👇 The effect is re-executed on state change.
-        if (store.token() && !store.currentUser()) {
-          console.log(
-            'Have a token, but no currentUser.  Should call /me endpoint, but here?',
-          );
-        }
-      });
+    async loadCurrentUser() {
+      patchState(store, { loginStatus: 'pending' });
+      const user = await firstValueFrom(authService.me());
+      if (user.errors) {
+        this.logout();
+      }
+      patchState(store, { currentUser: user, loginStatus: 'success' });
     },
-  }),
+  })),
   withStorageSync({
     key: '_arcwell_auth_', // key used when writing to/reading from storage
     autoSync: true, // read from storage on init and write on state changes - `true` by default


### PR DESCRIPTION
- updated app.component to get the user from `/me` when a token is present, but we don't have a current user
- removed code related to this ticket, but wasn't working
- updated auth.service to have a `.me()` method
-  updated auth.store to call the service and update the state