### PR TITLE
ARCWELL-293: Force npm install prior to development runs

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,7 @@ services:
     image: arcwell_server
     build:
       context: ./packages/server
+      target: develop
       args:
         NODE_ENV: development
         PORT: '3333'
@@ -41,6 +42,7 @@ services:
     image: arcwell_admin
     build:
       context: ./packages/admin
+      target: develop
       args:
         NODE_ENV: development
         PORT: '4200'

--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -1,12 +1,11 @@
 # Arcwell Admin
 # Dockerfile
 
-FROM node:20-bookworm-slim
+FROM node:20-bookworm-slim AS base
 
-LABEL project="arcwell-sandbox"
+LABEL project="Arcwell Admin"
 LABEL version="0.1"
-LABEL author.dev="Tim Getz <tgetz@arcwebtech.com>"
-LABEL author.co="Arcweb Technologies"
+LABEL author.co="Arcweb Technologies, LLC <https://arcweb.co>"
 
 # RUN apt-get update -qq \
 #     && apt-get install -qq vim \
@@ -46,42 +45,26 @@ WORKDIR /home/node/app
 
 # Copy in package defs first and install dependencies:
 COPY --chown=node:node package.json package-lock.json* ./
-RUN npm install && npm cache clean --force
-
-#COPY ng .
-
-#RUN mkdir scripts
-#COPY scripts/* scripts/
-#COPY npm-packages/* npm-packages/
-#COPY npm-packages/fontawesome/* npm-packages/fontawesome/
-
-# Make scripts executable
-#RUN chmod +x ./ng
-#RUN chmod +x ./scripts/install.sh
-#RUN chmod +x ./scripts/entrypoint.sh
-#RUN chmod +x ./scripts/entrypoint.ci.sh
-#RUN chmod +x ./scripts/tests-headless.sh
-#RUN chmod +x ./scripts/tests-start.sh
-
-# RUN echo "node version $(node -v); npm version $(npm -v)"
-
-# RUN npm install -g @angular/cli@18
-# RUN ng version
+RUN npm install --no-fund && npm cache clean --force
 
 # Add source code last (it changes the most), as node user:
-WORKDIR /home/node/app
 COPY --chown=node:node . .
 
-# RUN npm install --no-fund
-RUN npm install --no-fund
 
-#ARG CI_VERSION=1.0.LOCAL_DEV
-#RUN mkdir /etc/lvfiles
 #
-## Create a version file for the version endpoint
-#RUN echo "{\"version\":\"${CI_VERSION}\"}" > /etc/lvfiles/version.json
-#RUN cat /etc/lvfiles/version.json
+# Development
+#
+FROM base as develop
 
-#CMD "./scripts/entrypoint.sh"
+# In development build, always npm install prior to app start
+CMD npm install --no-fund; npm run dev
 
-CMD ["npm", "run", "dev"]
+
+#
+# Production
+#
+FROM base as production
+
+# In production build, just start server
+CMD ["npm", "run", "start"]
+

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,7 +1,7 @@
 # Arcwell Server
 # Dockerfile
 
-FROM node:20-bookworm-slim
+FROM node:20-bookworm-slim AS base
 
 # Set node environment, development or production
 # Default to production; override this in compose for development to build and run
@@ -21,15 +21,29 @@ WORKDIR /home/node/app
 
 # Copy in package defs first and install dependencies:
 COPY --chown=node:node package.json package-lock.json* ./
-##RUN npm ci && npm cache clean --force
-RUN npm install && npm cache clean --force
+RUN npm install --no-fund && npm cache clean --force
 
 # Check every 30s to ensure this service returns HTTP 200
 HEALTHCHECK --interval=60s CMD node healthcheck.js
 
 # Add source code last (it changes the most), as node user:
-WORKDIR /home/node/app
 COPY --chown=node:node . .
 
-CMD ["npm", "run", "dev"]
+
+#
+# Development
+#
+FROM base AS develop
+
+# In development build, always npm install prior to app start
+CMD npm install --no-fund; npm run dev
+
+
+#
+# Production
+#
+FROM base AS production
+
+# In production build, simply start server
+CMD ["npm", "run", "start"]
 


### PR DESCRIPTION
Force npm install prior to development runs
* Dockerfiles made multi-stage with develop, production
* Compose definition points to develop stage for admin, server
* npm install prefixes CMD in develop stages