### PR TITLE
feature/ARCWELL-290-prefill-type-on-create

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -26,7 +26,6 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
 
-
 ## Added eslint and prettier with schematics
 
 ** WORK IN PROGRESS **
@@ -59,7 +58,71 @@ rules: {
 },
 
 ```
+
 ## JetBrains IDE Configurations
 
-For IDE to recognize signalstore exposed signals,  enable proper typescript highlighting of signalStore
-  * Settings > Languages & Frameworks > TypeScript > Angular > WebStorm Angular TypeScript Plugin > Auto
+For IDE to recognize signalstore exposed signals, enable proper typescript highlighting of signalStore
+
+- Settings > Languages & Frameworks > TypeScript > Angular > WebStorm Angular TypeScript Plugin > Auto
+
+## VSCODE IDE Eslint, Prettier and Stylelint configuration
+
+The admin Angular application is configured to use EsLint, Prettier and Stylelint for code styling and linting. For developers using VSCode, there are 3 plugins required:
+
+1. Name: Prettier - Code formatter\
+   Id: esbenp.prettier-vscode\
+   Description: Code formatter using prettier\
+   Publisher: Prettier\
+   VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
+
+2. Name: ESLint\
+   Id: dbaeumer.vscode-eslint\
+   Description: Integrates ESLint JavaScript into VS Code.\
+   Publisher: Microsoft\
+   VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+
+3. Name: Stylelint\
+   Id: stylelint.vscode-stylelint\
+   Description: Official Stylelint extension for Visual Studio Code\
+   Publisher: Stylelint\
+   VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint
+
+You may also have to update your User `settings.json` by pressing `F1` and selecting `Preferences: Open User Settings`. Here is an example configuration to add to your existing user settings. This will enable formatting on save among other things:
+
+```json
+{
+  "eslint.workingDirectories": [
+    { "directory": "./packages/admin", "changeProcessCWD": true }
+  ],
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    },
+    "editor.formatOnSave": true
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    },
+    "editor.formatOnSave": true
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "stylelint.vscode-stylelint",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": "explicit"
+    },
+    "editor.formatOnSave": true
+  },
+  "stylelint.validate": ["css", "scss"],
+  "eslint.format.enable": true,
+  "editor.formatOnSave": true,
+  "eslint.useFlatConfig": true,
+  "prettier.requireConfig": true,
+  "eslint.validate": ["javascript", "typescript", "angular"],
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}
+```

--- a/packages/admin/src/app/feature/project-management/event/event.component.html
+++ b/packages/admin/src/app/feature/project-management/event/event.component.html
@@ -53,6 +53,7 @@
         type="datetime"
         formControlName="startedAt"
         [owlDateTime]="dt1"
+        data-lpignore="true"
       />
       <mat-icon class="event-icon" [owlDateTimeTrigger]="dt1">event</mat-icon>
       <owl-date-time #dt1></owl-date-time>
@@ -71,6 +72,7 @@
         type="datetime"
         formControlName="endedAt"
         [owlDateTime]="dt2"
+        data-lpignore="true"
       />
       <mat-icon class="event-icon" [owlDateTimeTrigger]="dt2">event</mat-icon>
       <owl-date-time #dt2></owl-date-time>

--- a/packages/admin/src/app/feature/project-management/event/event.component.ts
+++ b/packages/admin/src/app/feature/project-management/event/event.component.ts
@@ -73,9 +73,10 @@ export class EventComponent implements OnInit {
   destroyRef = inject(DestroyRef);
 
   @Input() eventId!: string;
+  @Input() typeKey?: string;
 
   eventForm = new FormGroup({
-    eventType: new FormControl(
+    eventType: new FormControl<EventTypeType | null>(
       { value: '', disabled: true },
       Validators.required,
     ),
@@ -98,6 +99,16 @@ export class EventComponent implements OnInit {
         this.eventForm.enable();
       } else {
         this.eventForm.disable();
+      }
+    });
+    effect(() => {
+      // update the form with the event type if typeKey is provided in the query params
+      if (this.eventStore.eventTypes() && this.typeKey) {
+        this.eventForm.patchValue({
+          eventType: this.eventStore
+            .eventTypes()
+            .find(et => et.key === this.typeKey),
+        });
       }
     });
   }

--- a/packages/admin/src/app/feature/project-management/events-list/events-list.component.html
+++ b/packages/admin/src/app/feature/project-management/events-list/events-list.component.html
@@ -5,6 +5,7 @@
       <button
         mat-icon-button
         [routerLink]="['/project-management/events/create']"
+        [queryParams]="{ typeKey: typeKey$ | async }"
       >
         <mat-icon aria-label="Create event icon button">
           add_circle_outline

--- a/packages/admin/src/app/feature/project-management/events-list/events-list.component.ts
+++ b/packages/admin/src/app/feature/project-management/events-list/events-list.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/material/table';
 import { EventModel } from '@app/shared/models/event.model';
 import { EventsListStore } from './events-list.store';
-import { JsonPipe } from '@angular/common';
+import { AsyncPipe, JsonPipe } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatPaginator } from '@angular/material/paginator';
 import { ErrorContainerComponent } from '../error-container/error-container.component';
@@ -31,6 +31,7 @@ import { MatSortModule, Sort } from '@angular/material/sort';
   selector: 'aw-events-list',
   standalone: true,
   imports: [
+    AsyncPipe,
     JsonPipe,
     MatTable,
     MatColumnDef,

--- a/packages/admin/src/app/feature/project-management/fact/fact.component.html
+++ b/packages/admin/src/app/feature/project-management/fact/fact.component.html
@@ -54,6 +54,7 @@
         formControlName="observedAt"
         [owlDateTime]="dt1"
         [owlDateTimeTrigger]="dt1"
+        data-lpignore="true"
       />
       <mat-icon class="event-icon" [owlDateTimeTrigger]="dt1">event</mat-icon>
       <owl-date-time #dt1></owl-date-time>

--- a/packages/admin/src/app/feature/project-management/fact/fact.component.ts
+++ b/packages/admin/src/app/feature/project-management/fact/fact.component.ts
@@ -95,9 +95,10 @@ export class FactComponent implements OnInit {
   readonly destroyRef = inject(DestroyRef);
 
   @Input() factId!: string;
+  @Input() typeKey?: string;
 
   factForm = new FormGroup({
-    factType: new FormControl(
+    factType: new FormControl<FactTypeType | null>(
       {
         value: null,
         disabled: true,
@@ -121,6 +122,16 @@ export class FactComponent implements OnInit {
         this.factForm.enable();
       } else {
         this.factForm.disable();
+      }
+    });
+    // update the form with the fact type if typeKey is provided in the query params
+    effect(() => {
+      if (this.factStore.factTypes() && this.typeKey) {
+        this.factForm.patchValue({
+          factType: this.factStore
+            .factTypes()
+            .find(pt => pt.key === this.typeKey),
+        });
       }
     });
   }

--- a/packages/admin/src/app/feature/project-management/facts-list/facts-list.component.html
+++ b/packages/admin/src/app/feature/project-management/facts-list/facts-list.component.html
@@ -1,7 +1,11 @@
 <div class="main-container-header">
   <h2>{{ featureStore.activeSubfeature()?.name || 'Facts' }}</h2>
   <div class="icons-container">
-    <button mat-icon-button [routerLink]="['/project-management/facts/create']">
+    <button
+      mat-icon-button
+      [routerLink]="['/project-management/facts/create']"
+      [queryParams]="{ typeKey: typeKey$ | async }"
+    >
       <mat-icon aria-label="Create fact icon button">
         add_circle_outline
       </mat-icon>

--- a/packages/admin/src/app/feature/project-management/facts-list/facts-list.component.ts
+++ b/packages/admin/src/app/feature/project-management/facts-list/facts-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, effect, inject } from '@angular/core';
-import { JsonPipe } from '@angular/common';
+import { AsyncPipe, JsonPipe } from '@angular/common';
 import { FactsListStore } from '@feature/project-management/facts-list/facts-list.store';
 import {
   MatCell,
@@ -31,6 +31,7 @@ import { MatSortModule, Sort } from '@angular/material/sort';
   selector: 'aw-all-facts',
   standalone: true,
   imports: [
+    AsyncPipe,
     JsonPipe,
     MatTable,
     MatColumnDef,

--- a/packages/admin/src/app/feature/project-management/people-list/people-list.component.html
+++ b/packages/admin/src/app/feature/project-management/people-list/people-list.component.html
@@ -6,6 +6,7 @@
     <button
       mat-icon-button
       [routerLink]="['/project-management/people/create']"
+      [queryParams]="{ typeKey: typeKey$ | async }"
     >
       <mat-icon aria-label="Create person icon button">
         add_circle_outline

--- a/packages/admin/src/app/feature/project-management/people-list/people-list.component.ts
+++ b/packages/admin/src/app/feature/project-management/people-list/people-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, effect, inject } from '@angular/core';
-import { JsonPipe } from '@angular/common';
+import { JsonPipe, AsyncPipe } from '@angular/common';
 import { PeopleListStore } from '@feature/project-management/people-list/people-list.store';
 import {
   MatCell,
@@ -29,6 +29,7 @@ import { MatSortModule, Sort } from '@angular/material/sort';
   selector: 'aw-people-list',
   standalone: true,
   imports: [
+    AsyncPipe,
     JsonPipe,
     MatTable,
     MatColumnDef,

--- a/packages/admin/src/app/feature/project-management/person/person.component.ts
+++ b/packages/admin/src/app/feature/project-management/person/person.component.ts
@@ -62,6 +62,7 @@ export class PersonComponent implements OnInit {
   readonly destroyRef = inject(DestroyRef);
 
   @Input() personId!: string;
+  @Input() typeKey?: string;
 
   personForm = new FormGroup({
     familyName: new FormControl(
@@ -78,7 +79,7 @@ export class PersonComponent implements OnInit {
       },
       Validators.required,
     ),
-    personType: new FormControl(
+    personType: new FormControl<PersonTypeType | null>(
       {
         value: null,
         disabled: true,
@@ -93,6 +94,16 @@ export class PersonComponent implements OnInit {
         this.personForm.enable();
       } else {
         this.personForm.disable();
+      }
+    });
+    // update the form with the person type if typeKey is provided in the query params
+    effect(() => {
+      if (this.personStore.personTypes() && this.typeKey) {
+        this.personForm.patchValue({
+          personType: this.personStore
+            .personTypes()
+            .find(pt => pt.key === this.typeKey),
+        });
       }
     });
   }
@@ -123,8 +134,8 @@ export class PersonComponent implements OnInit {
           }
         }
         // else if (event instanceof ValueChangeEvent) {
-        // }
         // This is here for an example.  Also, there are other events that can be caught
+        // }
       });
   }
 

--- a/packages/admin/src/app/feature/project-management/person/person.store.ts
+++ b/packages/admin/src/app/feature/project-management/person/person.store.ts
@@ -130,7 +130,6 @@ export const PersonStore = signalStore(
         }
       },
       async createPerson(createPersonFormData: PersonType) {
-        console.log('createPersonFormData', createPersonFormData);
         patchState(store, setPending());
         createPersonFormData.typeKey = createPersonFormData.personType.key;
 

--- a/packages/admin/src/app/feature/project-management/resource/resource.component.ts
+++ b/packages/admin/src/app/feature/project-management/resource/resource.component.ts
@@ -61,10 +61,11 @@ export class ResourceComponent implements OnInit {
   destoyRef = inject(DestroyRef);
 
   @Input() resourceId!: string;
+  @Input() typeKey?: string;
 
   resourceForm = new FormGroup({
     name: new FormControl({ value: '', disabled: true }, Validators.required),
-    resourceType: new FormControl(
+    resourceType: new FormControl<ResourceTypeType | null>(
       { value: '', disabled: true },
       Validators.required,
     ),
@@ -76,6 +77,15 @@ export class ResourceComponent implements OnInit {
         this.resourceForm.enable();
       } else {
         this.resourceForm.disable();
+      }
+    });
+    effect(() => {
+      if (this.resourceStore.resourceTypes() && this.typeKey) {
+        this.resourceForm.patchValue({
+          resourceType: this.resourceStore
+            .resourceTypes()
+            .find(rt => rt.key === this.typeKey),
+        });
       }
     });
   }

--- a/packages/admin/src/app/feature/project-management/resources-list/resources-list.component.html
+++ b/packages/admin/src/app/feature/project-management/resources-list/resources-list.component.html
@@ -5,6 +5,7 @@
       <button
         mat-icon-button
         [routerLink]="['/project-management/resources/create']"
+        [queryParams]="{ typeKey: typeKey$ | async }"
       >
         <mat-icon aria-label="Create resource icon button">
           add_circle_outline

--- a/packages/admin/src/app/feature/project-management/resources-list/resources-list.component.ts
+++ b/packages/admin/src/app/feature/project-management/resources-list/resources-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, effect, inject } from '@angular/core';
-import { JsonPipe } from '@angular/common';
+import { AsyncPipe, JsonPipe } from '@angular/common';
 import { ResourcesListStore } from '@feature/project-management/resources-list/resources-list.store';
 import {
   MatCell,
@@ -29,6 +29,7 @@ import { MatSortModule, Sort } from '@angular/material/sort';
   selector: 'aw-resources-list',
   standalone: true,
   imports: [
+    AsyncPipe,
     JsonPipe,
     MatTable,
     MatColumnDef,


### PR DESCRIPTION
- added functionality to prefill the `type` droplist when creating a new model which has a type
- added the `typeKey` query param to the create button so the component being routed to can see the type which was navigated from when creating a new object of that type
- updated the admin readme and added information about configuring VSCode for linting and code styling
- added last pass ignore tags on a few inputs which were trying to be prefilled