### PR TITLE
ARCWELL-196 and ARCWELL-367 Server Configuration

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,20 +1,24 @@
 # Arcwell Server Environment File
 
-# Arcwell Configuration:
-ARCWELL_NODE="Arcweb/Dev-Node"
-ARCWELL_KEY="LOCAL-DEV-SERVER"
+# Instance Configuration:
+ARCWELL_INSTANCE_NAME="Development Arcwell Server"
+ARCWELL_INSTANCE_ID=arcweb-dev
 
-# AdonisJS Configuration:
+# Mail Delivery:
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+
+# Server Config:
 TZ=UTC
 PORT=3333
 HOST=0.0.0.0
 LOG_LEVEL=info
 APP_KEY=$__APP_KEY__
 NODE_ENV=development
+
+# Database Connection:
 DB_HOST=db
 DB_PORT=5432
 DB_USER=arcwell
 DB_PASSWORD=arcwell
 DB_DATABASE=arcwell
-SMTP_HOST=mailhog
-SMTP_PORT=1025

--- a/packages/server/app/controllers/config_controller.ts
+++ b/packages/server/app/controllers/config_controller.ts
@@ -1,3 +1,4 @@
+import env from '#start/env'
 import type { HttpContext } from '@adonisjs/core/http'
 import {
   featureMenuConfig,
@@ -11,6 +12,24 @@ import EventType from '#models/event_type'
 import FactType from '#models/fact_type'
 
 export default class ConfigController {
+  /**
+   * @index
+   * @summary Config Index
+   * @description Returns a set of public server configuration fields for introspection by integrating apps.
+   */
+  async index() {
+    return {
+      arcwell: {
+        name: env.get('ARCWELL_INSTANCE_NAME'),
+        id: env.get('ARCWELL_INSTANCE_ID'),
+      },
+      mail: {
+        host: env.get('SMTP_HOST'),
+        port: env.get('SMTP_PORT'),
+      },
+    }
+  }
+
   /**
    * @featuresMenu
    * @summary Features Menu

--- a/packages/server/start/env.ts
+++ b/packages/server/start/env.ts
@@ -12,28 +12,25 @@
 import { Env } from '@adonisjs/core/env'
 
 export default await Env.create(new URL('../', import.meta.url), {
+  // Server configuration
   NODE_ENV: Env.schema.enum(['development', 'production', 'test'] as const),
   PORT: Env.schema.number(),
   APP_KEY: Env.schema.string(),
   HOST: Env.schema.string({ format: 'host' }),
   LOG_LEVEL: Env.schema.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']),
 
-  /*
-  |----------------------------------------------------------
-  | Variables for configuring database connection
-  |----------------------------------------------------------
-  */
+  // Arcwell instance configuration:
+  ARCWELL_INSTANCE_NAME: Env.schema.string(),
+  ARCWELL_INSTANCE_ID: Env.schema.string(),
+
+  // Database connection:
   DB_HOST: Env.schema.string({ format: 'host' }),
   DB_PORT: Env.schema.number(),
   DB_USER: Env.schema.string(),
   DB_PASSWORD: Env.schema.string.optional(),
   DB_DATABASE: Env.schema.string(),
 
-  /*
-  |----------------------------------------------------------
-  | Variables for configuring the mail package
-  |----------------------------------------------------------
-  */
+  // Mail system:
   SMTP_HOST: Env.schema.string(),
   SMTP_PORT: Env.schema.string(),
 })

--- a/packages/server/start/routes.ts
+++ b/packages/server/start/routes.ts
@@ -7,7 +7,6 @@
 |
 */
 
-import env from '#start/env'
 import router from '@adonisjs/core/services/router'
 const AuthController = () => import('#controllers/auth_controller')
 import { middleware } from '#start/kernel'
@@ -65,12 +64,15 @@ router.group(() => {
 })
 
 // config routes
-router.group(() => {
-  router.get('config/features-menu', [ConfigController, 'featuresMenu']).as('featuresMenu')
-})
+router
+  .group(() => {
+    router.get('', [ConfigController, 'index']).as('index')
+    router.get('features-menu', [ConfigController, 'featuresMenu']).as('featuresMenu')
+  })
+  .as('config')
+  .prefix('config')
 
 // fact routes
-
 router.group(() => {
   router.resource('facts/types', FactTypesController).apiOnly()
   router


### PR DESCRIPTION
Arcwell Instance Config and Config Server Endpoint
* Add Arcwell Instance config vars to Env for instance name and id
* Add /config index to server for config introspection (first portion of ARCWELL-367)
* Supprting updates to .env.example

NB: This completes ARCWELL-196 (sets new config variables and defaults) and ARCWELL-367 (adds the server config endpoint), but does not address ARCWELL-382 (create config store and display instance name within Admin)