### PR TITLE
feature/ARCWELL-419-tag-string-arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3527,7 +3527,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -3539,7 +3538,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5162,7 +5160,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -5193,7 +5190,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -7459,7 +7455,7 @@
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.13.tgz",
       "integrity": "sha512-eailUYex6fkfaQTev4Oa3mwn0/e3mQU4H8y1WPuImYQESOQDtVrowwUGDSc19evpBbHpKtwM+hw8nLlhIsF+Tw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7668,14 +7664,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.9.tgz",
       "integrity": "sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -7743,26 +7739,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
@@ -8799,7 +8791,6 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -9406,8 +9397,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -11327,8 +11317,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/critters": {
       "version": "0.0.24",
@@ -12081,7 +12070,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -17618,8 +17606,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/make-fetch-happen": {
       "version": "13.0.1",
@@ -23934,7 +23921,6 @@
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/ts-node-maintained/-/ts-node-maintained-10.9.4.tgz",
       "integrity": "sha512-Fq4c+LoWee4E0YWDBsotcBR8CB9pStBYBUuanQjXuOlLFescZ4uEODG8mdpDGGWYSCCaQXBjEgXzLIGu/NbyNw==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -24744,8 +24730,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/valid-url": {
       "version": "1.0.9",
@@ -25675,7 +25660,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -26220,7 +26204,8 @@
         "edge.js": "^6.2.0",
         "luxon": "^3.4.4",
         "pg": "^8.12.0",
-        "reflect-metadata": "^0.2.2"
+        "reflect-metadata": "^0.2.2",
+        "ts-node-maintained": "^10.9.4"
       },
       "devDependencies": {
         "@adonisjs/assembler": "^7.8.2",
@@ -26238,7 +26223,6 @@
         "hot-hook": "^0.2.6",
         "pino-pretty": "^11.2.1",
         "prettier": "^3.3.2",
-        "ts-node-maintained": "^10.9.4",
         "typescript": "~5.4"
       }
     }

--- a/packages/admin/src/app/feature/project-management/cohort/cohort.component.ts
+++ b/packages/admin/src/app/feature/project-management/cohort/cohort.component.ts
@@ -32,7 +32,6 @@ import { ConfirmationDialogComponent } from '@shared/components/dialogs/confirma
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Sort } from '@angular/material/sort';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
-import { TagType } from '@schemas/tag.schema';
 import { PeopleTableComponent } from '@app/shared/components/people-table/people-table.component';
 import { PageEvent } from '@angular/material/paginator';
 import { ObjectSelectorFormFieldComponent } from '@app/shared/component-library/form/object-selector-form-field/object-selector-form-field.component';
@@ -78,7 +77,7 @@ export class CohortComponent implements OnInit {
 
   @Input() cohortId!: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   cohortForm = new FormGroup({
     name: new FormControl(
@@ -205,7 +204,7 @@ export class CohortComponent implements OnInit {
     });
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.cohortStore.setTags(tags);
   }
 
@@ -252,7 +251,7 @@ export class CohortComponent implements OnInit {
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/cohort/cohort.store.ts
+++ b/packages/admin/src/app/feature/project-management/cohort/cohort.store.ts
@@ -16,7 +16,6 @@ import { CohortService } from '@shared/services/cohort.service';
 import { computed, inject } from '@angular/core';
 import { firstValueFrom, forkJoin } from 'rxjs';
 import { CohortType, CohortUpdateType } from '@shared/schemas/cohort.schema';
-import { TagType } from '@schemas/tag.schema';
 import { TagService } from '@shared/services/tag.service';
 import { ToastService } from '@shared/services/toast.service';
 import { ToastLevel } from '@shared/models';
@@ -312,8 +311,6 @@ export const CohortStore = signalStore(
     }),
   ),
   withComputed(({ cohort }) => ({
-    tagStrings: computed(
-      () => cohort()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
-    ),
+    tagStrings: computed(() => cohort()?.tags?.map((tag: string) => tag) ?? []),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/event-type/event-type.component.ts
+++ b/packages/admin/src/app/feature/project-management/event-type/event-type.component.ts
@@ -34,7 +34,6 @@ import { MatInput } from '@angular/material/input';
 import { MatSelect } from '@angular/material/select';
 import { ErrorContainerComponent } from '../error-container/error-container.component';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
-import { TagType } from '@schemas/tag.schema';
 import { autoSlugify } from '@app/shared/helpers/auto-slug.helper';
 import { BackButtonComponent } from '@app/shared/components/back-button/back-button.component';
 import { BackService } from '@app/shared/services/back.service';
@@ -73,7 +72,7 @@ export class EventTypeComponent implements OnInit {
 
   @Input() eventTypeId!: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   eventTypeForm = new FormGroup({
     name: new FormControl(
@@ -203,12 +202,12 @@ export class EventTypeComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.eventTypeStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/event-type/event-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/event-type/event-type.store.ts
@@ -17,7 +17,6 @@ import { firstValueFrom } from 'rxjs';
 import { EventType, EventUpdateType } from '@shared/schemas/event.schema';
 import { EventTypeService } from '@shared/services/event-type.service';
 import { TagService } from '@shared/services/tag.service';
-import { TagType } from '@schemas/tag.schema';
 import { FeatureStore } from '@app/shared/store/feature.store';
 import { Router } from '@angular/router';
 import { ToastService } from '@app/shared/services/toast.service';
@@ -164,7 +163,7 @@ export const EventTypeStore = signalStore(
   ),
   withComputed(({ eventType }) => ({
     tagStrings: computed(
-      () => eventType()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
+      () => eventType()?.tags?.map((tag: string) => tag) ?? [],
     ),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/event-types/event-types.component.html
+++ b/packages/admin/src/app/feature/project-management/event-types/event-types.component.html
@@ -29,7 +29,7 @@
         @if (element.tags && element.tags.length > 0) {
           @for (tag of element.tags; track $index) {
             <div>
-              {{ tag.pathname }}
+              {{ tag }}
             </div>
           }
         } @else {

--- a/packages/admin/src/app/feature/project-management/event/event.component.ts
+++ b/packages/admin/src/app/feature/project-management/event/event.component.ts
@@ -30,7 +30,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ConfirmationDialogComponent } from '@app/shared/components/dialogs/confirmation/confirmation-dialog.component';
 import { EventTypeType } from '@app/shared/schemas/event-type.schema';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
-import { TagType } from '@schemas/tag.schema';
 import {
   OwlDateTimeModule,
   OwlNativeDateTimeModule,
@@ -80,7 +79,7 @@ export class EventComponent implements OnInit {
   @Input() eventId!: string;
   @Input() typeKey?: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   eventForm = new FormGroup({
     eventType: new FormControl<EventTypeType | null>(
@@ -229,12 +228,12 @@ export class EventComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.eventStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/event/event.store.ts
+++ b/packages/admin/src/app/feature/project-management/event/event.store.ts
@@ -19,7 +19,6 @@ import { EventService } from '@app/shared/services/event.service';
 import { EventTypeService } from '@app/shared/services/event-type.service';
 import { firstValueFrom, forkJoin } from 'rxjs';
 import { TagService } from '@shared/services/tag.service';
-import { TagType } from '@schemas/tag.schema';
 import { ToastService } from '@app/shared/services/toast.service';
 import { Router } from '@angular/router';
 import { ToastLevel } from '@app/shared/models';
@@ -234,8 +233,6 @@ export const EventStore = signalStore(
     }),
   ),
   withComputed(({ event }) => ({
-    tagStrings: computed(
-      () => event()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
-    ),
+    tagStrings: computed(() => event()?.tags?.map((tag: string) => tag) ?? []),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/fact-type/fact-type.component.ts
+++ b/packages/admin/src/app/feature/project-management/fact-type/fact-type.component.ts
@@ -33,7 +33,6 @@ import { MatIcon } from '@angular/material/icon';
 import { ConfirmationDialogComponent } from '@shared/components/dialogs/confirmation/confirmation-dialog.component';
 import { FactTypeStore } from '@feature/project-management/fact-type/fact-type.store';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { TagType } from '@schemas/tag.schema';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
 import { autoSlugify } from '@app/shared/helpers/auto-slug.helper';
 import { BackButtonComponent } from '@app/shared/components/back-button/back-button.component';
@@ -97,7 +96,7 @@ export class FactTypeComponent implements OnInit {
 
   @Input() factTypeId!: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   factTypeForm = new FormGroup({
     name: new FormControl(
@@ -244,12 +243,12 @@ export class FactTypeComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.factTypeStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/fact-type/fact-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/fact-type/fact-type.store.ts
@@ -17,13 +17,10 @@ import { firstValueFrom } from 'rxjs';
 import { FactType } from '@schemas/fact.schema';
 import { FactTypeService } from '@shared/services/fact-type.service';
 import { TagService } from '@shared/services/tag.service';
-import { TagType } from '@schemas/tag.schema';
 import { FeatureStore } from '@app/shared/store/feature.store';
 import { ToastService } from '@app/shared/services/toast.service';
 import { Router } from '@angular/router';
 import { ToastLevel } from '@app/shared/models';
-import { FactTypeType, FactTypeUpdateType } from '@schemas/fact-type.schema';
-import { DimensionSchemaType } from '@schemas/dimension-schema.schema';
 
 interface FactTypeState {
   factType: FactType | null;
@@ -159,7 +156,7 @@ export const FactTypeStore = signalStore(
   ),
   withComputed(({ factType }) => ({
     tagStrings: computed(
-      () => factType()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
+      () => factType()?.tags?.map((tag: string) => tag) ?? [],
     ),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/fact-types/fact-types.component.html
+++ b/packages/admin/src/app/feature/project-management/fact-types/fact-types.component.html
@@ -29,7 +29,7 @@
         @if (element.tags && element.tags.length > 0) {
           @for (tag of element.tags; track $index) {
             <div>
-              {{ tag.pathname }}
+              {{ tag }}
             </div>
           }
         } @else {

--- a/packages/admin/src/app/feature/project-management/fact/fact.component.ts
+++ b/packages/admin/src/app/feature/project-management/fact/fact.component.ts
@@ -30,7 +30,6 @@ import { MatIcon } from '@angular/material/icon';
 import { ConfirmationDialogComponent } from '@shared/components/dialogs/confirmation/confirmation-dialog.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
-import { TagType } from '@schemas/tag.schema';
 import {
   MatCell,
   MatCellDef,
@@ -53,7 +52,7 @@ import { ResourceType } from '@schemas/resource.schema';
 import { EventType } from '@schemas/event.schema';
 import { BackButtonComponent } from '@app/shared/components/back-button/back-button.component';
 import { BackService } from '@app/shared/services/back.service';
-import { DetailHeaderComponent } from '../../../shared/components/detail-header/detail-header.component';
+import { DetailHeaderComponent } from '@shared/components/detail-header/detail-header.component';
 import { FactType } from '@app/shared/schemas/fact.schema';
 
 @Component({
@@ -104,7 +103,7 @@ export class FactComponent implements OnInit {
   @Input() factId!: string;
   @Input() typeKey?: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   factForm = new FormGroup({
     factType: new FormControl<FactTypeType | null>(
@@ -252,12 +251,12 @@ export class FactComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.factStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/fact/fact.store.ts
+++ b/packages/admin/src/app/feature/project-management/fact/fact.store.ts
@@ -18,7 +18,6 @@ import { firstValueFrom, forkJoin } from 'rxjs';
 import { FactType, FactUpdateType } from '@shared/schemas/fact.schema';
 import { FactTypeService } from '@shared/services/fact-type.service';
 import { FactTypeType } from '@schemas/fact-type.schema';
-import { TagType } from '@schemas/tag.schema';
 import { TagService } from '@shared/services/tag.service';
 import { ToastService } from '@shared/services/toast.service';
 import { ToastLevel } from '@shared/models';
@@ -230,8 +229,6 @@ export const FactStore = signalStore(
     }),
   ),
   withComputed(({ fact }) => ({
-    tagStrings: computed(
-      () => fact()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
-    ),
+    tagStrings: computed(() => fact()?.tags?.map((tag: string) => tag) ?? []),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/person-type/person-type.component.ts
+++ b/packages/admin/src/app/feature/project-management/person-type/person-type.component.ts
@@ -33,7 +33,6 @@ import { MatIcon } from '@angular/material/icon';
 import { ConfirmationDialogComponent } from '@shared/components/dialogs/confirmation/confirmation-dialog.component';
 import { PersonTypeStore } from '@feature/project-management/person-type/person-type.store';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { TagType } from '@schemas/tag.schema';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
 import { autoSlugify } from '@shared/helpers/auto-slug.helper';
 import { BackButtonComponent } from '@shared/components/back-button/back-button.component';
@@ -73,7 +72,7 @@ export class PersonTypeComponent implements OnInit {
 
   @Input() personTypeId!: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   personTypeForm = new FormGroup({
     name: new FormControl(
@@ -201,12 +200,12 @@ export class PersonTypeComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.personTypeStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/person-type/person-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/person-type/person-type.store.ts
@@ -17,7 +17,6 @@ import { firstValueFrom } from 'rxjs';
 import { PersonType, PersonUpdateType } from '@shared/schemas/person.schema';
 import { PersonTypeService } from '@shared/services/person-type.service';
 import { TagService } from '@shared/services/tag.service';
-import { TagType } from '@schemas/tag.schema';
 import { FeatureStore } from '@app/shared/store/feature.store';
 import { Router } from '@angular/router';
 import { ToastService } from '@app/shared/services/toast.service';
@@ -167,7 +166,7 @@ export const PersonTypeStore = signalStore(
   ),
   withComputed(({ personType }) => ({
     tagStrings: computed(
-      () => personType()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
+      () => personType()?.tags?.map((tag: string) => tag) ?? [],
     ),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/person-types/person-types.component.html
+++ b/packages/admin/src/app/feature/project-management/person-types/person-types.component.html
@@ -30,7 +30,7 @@
         @if (element.tags && element.tags.length > 0) {
           @for (tag of element.tags; track $index) {
             <div>
-              {{ tag.pathname }}
+              {{ tag }}
             </div>
           }
         } @else {

--- a/packages/admin/src/app/feature/project-management/person/person.component.ts
+++ b/packages/admin/src/app/feature/project-management/person/person.component.ts
@@ -32,14 +32,13 @@ import { MatTableDataSource } from '@angular/material/table';
 import { ConfirmationDialogComponent } from '@shared/components/dialogs/confirmation/confirmation-dialog.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TagsFormComponent } from '@shared/components/tags-form/tags-form.component';
-import { TagType } from '@schemas/tag.schema';
 import { BackButtonComponent } from '@app/shared/components/back-button/back-button.component';
 import { BackService } from '@app/shared/services/back.service';
 import { ObjectSelectorFormFieldComponent } from '@app/shared/component-library/form/object-selector-form-field/object-selector-form-field.component';
 import { CohortTableComponent } from '@app/shared/components/cohort-table/cohort-table.component';
 import { CohortType } from '@app/shared/schemas/cohort.schema';
 import { CohortModel } from '@app/shared/models/cohort.model';
-import { DetailHeaderComponent } from '../../../shared/components/detail-header/detail-header.component';
+import { DetailHeaderComponent } from '@shared/components/detail-header/detail-header.component';
 import { PersonType } from '@app/shared/schemas/person.schema';
 
 @Component({
@@ -79,7 +78,7 @@ export class PersonComponent implements OnInit {
   @Input() personId!: string;
   @Input() typeKey?: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   personForm = new FormGroup({
     familyName: new FormControl(
@@ -229,7 +228,7 @@ export class PersonComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.personStore.setTags(tags);
   }
 
@@ -264,7 +263,7 @@ export class PersonComponent implements OnInit {
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/person/person.store.ts
+++ b/packages/admin/src/app/feature/project-management/person/person.store.ts
@@ -18,7 +18,6 @@ import { firstValueFrom, forkJoin } from 'rxjs';
 import { PersonType, PersonUpdateType } from '@shared/schemas/person.schema';
 import { PersonTypeService } from '@shared/services/person-type.service';
 import { PersonTypeType } from '@schemas/person-type.schema';
-import { TagType } from '@schemas/tag.schema';
 import { TagService } from '@shared/services/tag.service';
 import { ToastService } from '@shared/services/toast.service';
 import { ToastLevel } from '@shared/models';
@@ -299,8 +298,6 @@ export const PersonStore = signalStore(
     }),
   ),
   withComputed(({ person }) => ({
-    tagStrings: computed(
-      () => person()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
-    ),
+    tagStrings: computed(() => person()?.tags?.map((tag: string) => tag) ?? []),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/resource-type/resource-type.component.ts
+++ b/packages/admin/src/app/feature/project-management/resource-type/resource-type.component.ts
@@ -32,7 +32,6 @@ import {
   TYPE_KEY_PATTERN,
 } from '@app/shared/constants/admin.constants';
 import { ResourceTypeType } from '@app/shared/schemas/resource-type.schema';
-import { TagType } from '@app/shared/schemas/tag.schema';
 import { ErrorContainerComponent } from '../error-container/error-container.component';
 import { ResourceTypeStore } from '../resource-type/resource-type.store';
 import { autoSlugify } from '@app/shared/helpers/auto-slug.helper';
@@ -73,7 +72,7 @@ export class ResourceTypeComponent implements OnInit {
 
   @Input() resourceTypeId!: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   resourceTypeForm = new FormGroup({
     name: new FormControl(
@@ -202,12 +201,12 @@ export class ResourceTypeComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.resourceTypeStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/resource-type/resource-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/resource-type/resource-type.store.ts
@@ -16,7 +16,6 @@ import { computed, inject } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { ResourceTypeService } from '@shared/services/resource-type.service';
 import { TagService } from '@shared/services/tag.service';
-import { TagType } from '@schemas/tag.schema';
 import { ResourceTypeType } from '@app/shared/schemas/resource-type.schema';
 import {
   ResourceType,
@@ -175,7 +174,7 @@ export const ResourceTypeStore = signalStore(
   ),
   withComputed(({ resourceType }) => ({
     tagStrings: computed(
-      () => resourceType()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
+      () => resourceType()?.tags?.map((tag: string) => tag) ?? [],
     ),
   })),
 );

--- a/packages/admin/src/app/feature/project-management/resource-types/resource-types.component.html
+++ b/packages/admin/src/app/feature/project-management/resource-types/resource-types.component.html
@@ -32,7 +32,7 @@
         @if (element.tags && element.tags.length > 0) {
           @for (tag of element.tags; track $index) {
             <div>
-              {{ tag.pathname }}
+              {{ tag }}
             </div>
           }
         } @else {

--- a/packages/admin/src/app/feature/project-management/resource/resource.component.ts
+++ b/packages/admin/src/app/feature/project-management/resource/resource.component.ts
@@ -29,11 +29,10 @@ import { ConfirmationDialogComponent } from '@app/shared/components/dialogs/conf
 import { TagsFormComponent } from '@app/shared/components/tags-form/tags-form.component';
 import { CREATE_PARTIAL_URL } from '@app/shared/constants/admin.constants';
 import { ResourceTypeType } from '@app/shared/schemas/resource-type.schema';
-import { TagType } from '@app/shared/schemas/tag.schema';
 import { ErrorContainerComponent } from '../error-container/error-container.component';
 import { BackButtonComponent } from '@app/shared/components/back-button/back-button.component';
 import { BackService } from '@app/shared/services/back.service';
-import { DetailHeaderComponent } from '../../../shared/components/detail-header/detail-header.component';
+import { DetailHeaderComponent } from '@shared/components/detail-header/detail-header.component';
 import { ResourceType } from '@app/shared/schemas/resource.schema';
 
 @Component({
@@ -62,15 +61,14 @@ import { ResourceType } from '@app/shared/schemas/resource.schema';
 })
 export class ResourceComponent implements OnInit {
   readonly resourceStore = inject(ResourceStore);
-  private router = inject(Router);
   readonly dialog = inject(MatDialog);
-  destoyRef = inject(DestroyRef);
+  destroyRef = inject(DestroyRef);
   readonly backService = inject(BackService);
 
   @Input() resourceId!: string;
   @Input() typeKey?: string;
 
-  tagsForCreate: TagType[] = [];
+  tagsForCreate: string[] = [];
 
   resourceForm = new FormGroup({
     name: new FormControl({ value: '', disabled: true }, Validators.required),
@@ -114,7 +112,7 @@ export class ResourceComponent implements OnInit {
     }
 
     this.resourceForm.events
-      .pipe(takeUntilDestroyed(this.destoyRef))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(resource => {
         if ((resource as ControlEvent) instanceof FormSubmittedEvent) {
           if (this.resourceStore.inCreateMode()) {
@@ -175,12 +173,12 @@ export class ResourceComponent implements OnInit {
     return pt1 && pt2 ? pt1.id === pt2.id : false;
   }
 
-  onSetTags(tags: TagType[]): void {
+  onSetTags(tags: string[]): void {
     this.resourceStore.setTags(tags);
   }
 
   // This should only be used during object creation
-  updateTagsForCreate(tags: TagType[]) {
+  updateTagsForCreate(tags: string[]) {
     this.tagsForCreate = tags;
   }
 }

--- a/packages/admin/src/app/feature/project-management/resource/resource.store.ts
+++ b/packages/admin/src/app/feature/project-management/resource/resource.store.ts
@@ -21,7 +21,6 @@ import { computed, inject } from '@angular/core';
 import { ResourceService } from '@app/shared/services/resource.service';
 import { firstValueFrom, forkJoin } from 'rxjs';
 import { TagService } from '@shared/services/tag.service';
-import { TagType } from '@schemas/tag.schema';
 import { ResourceTypeService } from '@app/shared/services/resource-type.service';
 import { Router } from '@angular/router';
 import { ToastService } from '@app/shared/services/toast.service';
@@ -193,7 +192,7 @@ export const ResourceStore = signalStore(
   ),
   withComputed(({ resource }) => ({
     tagStrings: computed(
-      () => resource()?.tags?.map((tag: TagType) => tag.pathname) ?? [],
+      () => resource()?.tags?.map((tag: string) => tag) ?? [],
     ),
   })),
 );

--- a/packages/admin/src/app/shared/components/cohort-table/cohort-table.component.html
+++ b/packages/admin/src/app/shared/components/cohort-table/cohort-table.component.html
@@ -1,37 +1,33 @@
-<table
-  mat-table
-  [dataSource]="dataSource()"
-  class="mat-elevation-z0"
->
-<ng-container matColumnDef="id">
-  <th mat-header-cell *matHeaderCellDef>Id</th>
-  <td mat-cell *matCellDef="let element">{{ element.id }}</td>
-</ng-container>
+<table mat-table [dataSource]="dataSource()" class="mat-elevation-z0">
+  <ng-container matColumnDef="id">
+    <th mat-header-cell *matHeaderCellDef>Id</th>
+    <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+  </ng-container>
 
-<ng-container matColumnDef="name">
-  <th mat-header-cell *matHeaderCellDef>Name</th>
-  <td mat-cell *matCellDef="let element">{{ element.name }}</td>
-</ng-container>
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+  </ng-container>
 
-<ng-container matColumnDef="description">
-  <th mat-header-cell *matHeaderCellDef>Description</th>
-  <td mat-cell *matCellDef="let element">{{ element.description }}</td>
-</ng-container>
+  <ng-container matColumnDef="description">
+    <th mat-header-cell *matHeaderCellDef>Description</th>
+    <td mat-cell *matCellDef="let element">{{ element.description }}</td>
+  </ng-container>
 
-<ng-container matColumnDef="tags">
-  <th mat-header-cell *matHeaderCellDef>Tags</th>
-  <td mat-cell *matCellDef="let element">
-    @if (element.tags && element.tags.length > 0) {
-      @for (tag of element.tags; track $index) {
-        <div>
-          {{ tag.pathname }}
-        </div>
+  <ng-container matColumnDef="tags">
+    <th mat-header-cell *matHeaderCellDef>Tags</th>
+    <td mat-cell *matCellDef="let element">
+      @if (element.tags && element.tags.length > 0) {
+        @for (tag of element.tags; track $index) {
+          <div>
+            {{ tag }}
+          </div>
+        }
+      } @else {
+        <div>--</div>
       }
-    } @else {
-      <div>--</div>
-    }
-  </td>
-</ng-container>
+    </td>
+  </ng-container>
 
   <ng-container matColumnDef="delete">
     <th mat-header-cell *matHeaderCellDef></th>

--- a/packages/admin/src/app/shared/components/events-table/events-table.component.html
+++ b/packages/admin/src/app/shared/components/events-table/events-table.component.html
@@ -66,7 +66,7 @@
       @if (element.tags && element.tags.length > 0) {
         @for (tag of element.tags; track $index) {
           <div>
-            {{ tag.pathname }}
+            {{ tag }}
           </div>
         }
       } @else {

--- a/packages/admin/src/app/shared/components/facts-table/facts-table.component.html
+++ b/packages/admin/src/app/shared/components/facts-table/facts-table.component.html
@@ -74,7 +74,7 @@
       @if (element.tags && element.tags.length > 0) {
         @for (tag of element.tags; track $index) {
           <div>
-            {{ tag.pathname }}
+            {{ tag }}
           </div>
         }
       } @else {

--- a/packages/admin/src/app/shared/components/resources-table/resources-table.component.html
+++ b/packages/admin/src/app/shared/components/resources-table/resources-table.component.html
@@ -25,7 +25,7 @@
       @if (element.tags && element.tags.length > 0) {
         @for (tag of element.tags; track $index) {
           <div>
-            {{ tag.pathname }}
+            {{ tag }}
           </div>
         }
       } @else {

--- a/packages/admin/src/app/shared/components/tags-form/tags-form.component.ts
+++ b/packages/admin/src/app/shared/components/tags-form/tags-form.component.ts
@@ -16,7 +16,6 @@ import {
   FormsModule,
   FormSubmittedEvent,
   ReactiveFormsModule,
-  Validators,
   ValueChangeEvent,
 } from '@angular/forms';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';

--- a/packages/admin/src/app/shared/components/users-table/users-table.component.html
+++ b/packages/admin/src/app/shared/components/users-table/users-table.component.html
@@ -29,7 +29,7 @@
       @if (element.tags && element.tags.length > 0) {
         @for (tag of element.tags; track $index) {
           <div>
-            {{ tag.pathname }}
+            {{ tag }}
           </div>
         }
       } @else {

--- a/packages/admin/src/app/shared/models/cohort.model.ts
+++ b/packages/admin/src/app/shared/models/cohort.model.ts
@@ -1,7 +1,5 @@
 import { DateTime } from 'luxon';
 import { CohortUpdateType } from '@schemas/cohort.schema';
-import { TagType } from '@schemas/tag.schema';
-import { TagModel } from './tag.model';
 import { PersonModel } from './person.model';
 import { PersonType } from '@schemas/person.schema';
 
@@ -11,7 +9,7 @@ interface CohortBase {
   rules?: object;
   people?: PersonModel[] | undefined;
   peopleCount?: number;
-  tags?: TagModel[] | undefined;
+  tags?: string[] | undefined;
   createdAt: DateTime;
   updatedAt: DateTime;
 }
@@ -29,7 +27,7 @@ export class CohortModel {
   public name: string;
   public description?: string;
   public rules?: object;
-  public tags?: TagModel[] | undefined;
+  public tags?: string[] | undefined;
   public people?: PersonModel[] | undefined;
   public peopleCount?: number;
 
@@ -41,9 +39,7 @@ export class CohortModel {
     this.name = data.name;
     this.description = data.description;
     this.rules = data.rules;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
     this.people = data.people
       ? data.people.map((person: PersonType) => new PersonModel(person))
       : undefined;

--- a/packages/admin/src/app/shared/models/event-type.model.ts
+++ b/packages/admin/src/app/shared/models/event-type.model.ts
@@ -1,14 +1,12 @@
 import { DateTime } from 'luxon';
 import { EventTypeType } from '@shared/schemas/event-type.schema';
-import { TagModel } from '@shared/models/tag.model';
-import { TagType } from '@schemas/tag.schema';
 
 export class EventTypeModel {
   public id?: string;
   public key: string;
   public name: string;
   public description?: string;
-  public tags?: TagModel[];
+  public tags?: string[];
   public createdAt?: DateTime;
   public updatedAt?: DateTime;
 
@@ -18,9 +16,7 @@ export class EventTypeModel {
     this.name = data.name;
     this.description = data.description;
 
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
 
     if (data.createdAt) this.createdAt = DateTime.fromISO(data.createdAt);
     if (data.updatedAt) this.updatedAt = DateTime.fromISO(data.updatedAt);

--- a/packages/admin/src/app/shared/models/event.model.ts
+++ b/packages/admin/src/app/shared/models/event.model.ts
@@ -1,8 +1,6 @@
 import { DateTime } from 'luxon';
 import { EventTypeModel } from '@shared/models/event-type.model';
 import { EventType } from '@shared/schemas/event.schema';
-import { TagType } from '@schemas/tag.schema';
-import { TagModel } from '@shared/models/tag.model';
 import { PersonType } from '@schemas/person.schema';
 import { ResourceType } from '@schemas/resource.schema';
 import { PersonModel } from '@shared/models/person.model';
@@ -10,7 +8,7 @@ import { ResourceModel } from '@shared/models/resource.model';
 
 interface EventBase {
   typeKey: string;
-  tags?: TagModel[];
+  tags?: string[];
   info?: object;
   startedAt?: DateTime;
   endedAt?: DateTime;
@@ -37,7 +35,7 @@ export class EventModel {
   public info?: object;
   public startedAt?: DateTime;
   public endedAt?: DateTime;
-  public tags?: TagModel[];
+  public tags?: string[];
   public createdAt: DateTime;
   public updatedAt: DateTime;
   public eventType?: EventTypeModel;
@@ -56,9 +54,7 @@ export class EventModel {
     this.endedAt = data.endedAt ? DateTime.fromISO(data.endedAt) : undefined;
     this.createdAt = DateTime.fromISO(data.createdAt);
     this.updatedAt = DateTime.fromISO(data.updatedAt);
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
     this.eventType = data.eventType
       ? new EventTypeModel(data.eventType)
       : undefined;

--- a/packages/admin/src/app/shared/models/fact-type.model.ts
+++ b/packages/admin/src/app/shared/models/fact-type.model.ts
@@ -1,7 +1,5 @@
 import { DateTime } from 'luxon';
 import { FactType } from '@shared/schemas/fact.schema';
-import { TagType } from '@schemas/tag.schema';
-import { TagModel } from '@shared/models/tag.model';
 import { DimensionSchemaModel } from '@shared/models/dimension-schema.model';
 import { DimensionSchemaType } from '@schemas/dimension-schema.schema';
 
@@ -11,7 +9,7 @@ export class FactTypeModel {
   public name: string;
   public description?: string;
   public dimensionSchemas: DimensionSchemaModel[] | undefined;
-  public tags?: TagModel[];
+  public tags?: string[];
   public createdAt?: DateTime;
   public updatedAt?: DateTime;
 
@@ -20,9 +18,7 @@ export class FactTypeModel {
     this.key = data.key;
     this.name = data.name;
     this.description = data.description;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
 
     if (data.dimensionSchemas) {
       this.dimensionSchemas = data.dimensionSchemas.map(

--- a/packages/admin/src/app/shared/models/fact.model.ts
+++ b/packages/admin/src/app/shared/models/fact.model.ts
@@ -1,8 +1,6 @@
 import { DateTime } from 'luxon';
 import { FactUpdateType } from '@shared/schemas/fact.schema';
 import { FactTypeModel } from '@shared/models/fact-type.model';
-import { TagModel } from '@shared/models/tag.model';
-import { TagType } from '@schemas/tag.schema';
 import { PersonType } from '@schemas/person.schema';
 import { EventType } from '@schemas/event.schema';
 import { PersonModel } from '@shared/models/person.model';
@@ -21,7 +19,7 @@ interface FactBase {
   person?: PersonType | undefined;
   resource?: ResourceType | undefined;
   event?: EventType | undefined;
-  tags?: TagModel[] | undefined;
+  tags?: string[] | undefined;
   info?: object;
   observedAt?: DateTime;
   dimensions: DimensionModel[] | undefined;
@@ -50,7 +48,7 @@ export class FactModel {
   public person?: PersonType;
   public resource?: ResourceType;
   public event?: EventType;
-  public tags?: TagModel[];
+  public tags?: string[];
   public info?: object;
   public observedAt?: DateTime;
   public dimensions: DimensionModel[] | undefined;
@@ -77,8 +75,7 @@ export class FactModel {
       ? DateTime.fromISO(data.observedAt)
       : undefined;
 
-    if (data.tags)
-      this.tags = data.tags.map((tag: TagType) => new TagModel(tag));
+    this.tags = data.tags;
 
     if (data.dimensions) {
       this.dimensions = data.dimensions.map(

--- a/packages/admin/src/app/shared/models/person-type.model.ts
+++ b/packages/admin/src/app/shared/models/person-type.model.ts
@@ -1,14 +1,12 @@
 import { DateTime } from 'luxon';
 import { PersonType } from '@shared/schemas/person.schema';
-import { TagType } from '@schemas/tag.schema';
-import { TagModel } from '@shared/models/tag.model';
 
 export class PersonTypeModel {
   public id?: string;
   public key: string;
   public name: string;
   public description?: string;
-  public tags?: TagModel[] | undefined;
+  public tags?: string[] | undefined;
   public createdAt: DateTime;
   public updatedAt: DateTime;
 
@@ -17,9 +15,7 @@ export class PersonTypeModel {
     this.key = data.key;
     this.name = data.name;
     this.description = data.description;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
     this.createdAt = DateTime.fromISO(data.createdAt);
     this.updatedAt = DateTime.fromISO(data.updatedAt);
   }

--- a/packages/admin/src/app/shared/models/person.model.ts
+++ b/packages/admin/src/app/shared/models/person.model.ts
@@ -3,8 +3,6 @@ import { PersonUpdateType } from '@shared/schemas/person.schema';
 import { PersonTypeModel } from '@shared/models/person-type.model';
 import { UserModel } from '@shared/models/user.model';
 import { UserType } from '@schemas/user.schema';
-import { TagModel } from '@shared/models/tag.model';
-import { TagType } from '@schemas/tag.schema';
 import { CohortModel } from '@shared/models/cohort.model';
 import { CohortType } from '@schemas/cohort.schema';
 
@@ -13,7 +11,7 @@ interface PersonBase {
   familyName: string;
   givenName: string;
   typeKey: string;
-  tags?: TagModel[];
+  tags?: string[];
   info?: object;
   cohorts?: CohortModel[] | undefined;
   cohortsCount?: number;
@@ -39,7 +37,7 @@ export class PersonModel {
   public familyName: string;
   public givenName: string;
   public typeKey: string;
-  public tags?: TagModel[];
+  public tags?: string[];
   public info?: object;
   public cohorts?: CohortModel[] | undefined;
   public cohortsCount?: number;
@@ -53,9 +51,7 @@ export class PersonModel {
     this.familyName = data.familyName;
     this.givenName = data.givenName;
     this.typeKey = data.typeKey;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
     this.info = data.info;
     this.cohorts = data.cohorts
       ? data.cohorts.map((cohort: CohortType) => new CohortModel(cohort))

--- a/packages/admin/src/app/shared/models/resource-type.model.ts
+++ b/packages/admin/src/app/shared/models/resource-type.model.ts
@@ -1,14 +1,12 @@
 import { DateTime } from 'luxon';
 import { ResourceTypeType } from '@shared/schemas/resource-type.schema';
-import { TagModel } from '@shared/models/tag.model';
-import { TagType } from '@schemas/tag.schema';
 
 export class ResourceTypeModel {
   public id?: string;
   public key: string;
   public name: string;
   public description?: string;
-  public tags?: TagModel[];
+  public tags?: string[];
   public createdAt?: DateTime;
   public updatedAt?: DateTime;
 
@@ -17,9 +15,7 @@ export class ResourceTypeModel {
     this.key = data.key;
     this.name = data.name;
     this.description = data.description;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
 
     if (data.createdAt) this.createdAt = DateTime.fromISO(data.createdAt);
     if (data.updatedAt) this.updatedAt = DateTime.fromISO(data.updatedAt);

--- a/packages/admin/src/app/shared/models/resource.model.ts
+++ b/packages/admin/src/app/shared/models/resource.model.ts
@@ -1,14 +1,12 @@
 import { DateTime } from 'luxon';
-import { ResourceUpdateType } from '../schemas/resource.schema';
-import { TagType } from '../schemas/tag.schema';
+import { ResourceUpdateType } from '@schemas/resource.schema';
 import { ResourceTypeModel } from './resource-type.model';
-import { TagModel } from './tag.model';
 
 interface ResourceBase {
   name: string;
   info?: object;
   typeKey: string;
-  tags?: TagModel[] | undefined;
+  tags?: string[] | undefined;
   createdAt: DateTime;
   updatedAt: DateTime;
   resourceType?: ResourceTypeModel;
@@ -27,7 +25,7 @@ export class ResourceModel {
   public name: string;
   public info?: object;
   public typeKey: string;
-  public tags?: TagModel[] | undefined;
+  public tags?: string[] | undefined;
   public createdAt: DateTime;
   public updatedAt: DateTime;
   public resourceType?: ResourceTypeModel;
@@ -37,9 +35,7 @@ export class ResourceModel {
     this.name = data.name;
     this.info = data.info;
     this.typeKey = data.typeKey;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
     this.createdAt = DateTime.fromISO(data.createdAt);
     this.updatedAt = DateTime.fromISO(data.updatedAt);
     this.resourceType = data.resourceType

--- a/packages/admin/src/app/shared/models/user.model.ts
+++ b/packages/admin/src/app/shared/models/user.model.ts
@@ -1,9 +1,7 @@
 import { DateTime } from 'luxon';
-import { UserType } from '../schemas/user.schema';
+import { UserType } from '@schemas/user.schema';
 import { RoleModel } from './role.model';
 import { PersonModel } from './person.model';
-import { TagType } from '@schemas/tag.schema';
-import { TagModel } from '@shared/models/tag.model';
 
 export class UserModel {
   public id?: string;
@@ -15,7 +13,7 @@ export class UserModel {
   public info?: object;
   public role?: RoleModel;
   public person?: PersonModel;
-  public tags?: TagModel[];
+  public tags?: string[];
   public requiresPasswordChange?: boolean;
 
   constructor(data: UserType) {
@@ -28,9 +26,7 @@ export class UserModel {
     this.info = data.info;
     this.role = data.role ? new RoleModel(data.role) : undefined;
     this.person = data.person ? new PersonModel(data.person) : undefined;
-    this.tags = data.tags
-      ? data.tags.map((tag: TagType) => new TagModel(tag))
-      : undefined;
+    this.tags = data.tags;
     this.requiresPasswordChange = data.requiresPasswordChange;
   }
 

--- a/packages/admin/src/app/shared/schemas/cohort.schema.ts
+++ b/packages/admin/src/app/shared/schemas/cohort.schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { TagSchema } from './tag.schema';
 import { CohortModel } from '../models/cohort.model';
 import { PersonSchema } from './person.schema';
 
@@ -9,7 +8,7 @@ export const CohortSchema: any = z
     name: z.string(),
     description: z.string().optional().nullable(),
     rules: z.object({}).passthrough(),
-    tags: z.array(TagSchema).optional(),
+    tags: z.array(z.string()).optional(),
     people: z.lazy(() => z.array(PersonSchema).optional()),
     peopleCount: z.number().optional().nullable(),
     createdAt: z.string().datetime({ offset: true }).optional(),

--- a/packages/admin/src/app/shared/schemas/event-type.schema.ts
+++ b/packages/admin/src/app/shared/schemas/event-type.schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { EventSchema } from './event.schema';
 import { EventTypeModel } from '../models/event-type.model';
-import { TagSchema } from '@schemas/tag.schema';
 
 export const EventTypeSchema: any = z
   .object({
@@ -9,7 +8,7 @@ export const EventTypeSchema: any = z
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     events: z.array(EventSchema).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),
@@ -22,7 +21,7 @@ export const EventTypeUpdateSchema = z
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     events: z.array(EventSchema).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),

--- a/packages/admin/src/app/shared/schemas/event.schema.ts
+++ b/packages/admin/src/app/shared/schemas/event.schema.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 import { EventTypeSchema } from './event-type.schema';
 import { EventModel } from '../models/event.model';
-import { TagSchema } from '@schemas/tag.schema';
-import { FactSchema } from './fact.schema';
 import { PersonSchema } from '@schemas/person.schema';
 import { ResourceSchema } from '@schemas/resource.schema';
 
@@ -10,7 +8,7 @@ export const EventSchema: any = z
   .object({
     id: z.string().uuid().optional(),
     typeKey: z.string(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     info: z.object({}).passthrough(),
     eventType: EventTypeSchema.optional(),
     startedAt: z.string().datetime({ offset: true }),
@@ -27,7 +25,7 @@ export const EventSchema: any = z
 export const EventUpdateSchema = EventSchema.extend({
   id: z.string().uuid(),
   typeKey: z.string().optional(),
-  tags: z.lazy(() => z.array(TagSchema).optional()),
+  tags: z.array(z.string()).optional(),
   info: z.object({}).passthrough().optional(),
   startedAt: z.string().datetime({ offset: true }).optional(),
   endedAt: z.string().datetime({ offset: true }).optional().nullable(),

--- a/packages/admin/src/app/shared/schemas/fact-type.schema.ts
+++ b/packages/admin/src/app/shared/schemas/fact-type.schema.ts
@@ -1,43 +1,28 @@
 import { z } from 'zod';
 import { FactSchema } from './fact.schema';
 import { FactTypeModel } from '../models/fact-type.model';
-import { TagSchema } from '@schemas/tag.schema';
-import {
-  DimensionSchemaSchema,
-  DimensionSchemaUpdateSchema,
-} from '@schemas/dimension-schema.schema';
+import { DimensionSchemaSchema } from '@schemas/dimension-schema.schema';
 
 export const FactTypeSchema = z
   .object({
-    id: z.string().uuid().optional(),
+    id: z.string().uuid(), //.optional(),
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
     observedAt: z.string().datetime({ offset: true }).optional(),
     facts: z.array(FactSchema).optional(),
     dimensionSchemas: z.array(DimensionSchemaSchema.optional()).optional(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     createdAt: z.string().datetime({ offset: true }).optional().nullable(),
     updatedAt: z.string().datetime({ offset: true }).optional().nullable(),
   })
   .strict();
 
-export const FactTypeUpdateSchema = z
-  .object({
-    id: z.string().uuid(),
-    key: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional().nullable(),
-    observedAt: z.string().datetime({ offset: true }).optional(),
-    facts: z.array(FactSchema).optional(),
-    dimensionSchemas: z
-      .array(DimensionSchemaUpdateSchema.optional())
-      .optional(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
-    createdAt: z.string().datetime({ offset: true }).optional().nullable(),
-    updatedAt: z.string().datetime({ offset: true }).optional().nullable(),
-  })
-  .strict();
+export const FactTypeNewSchema = FactTypeSchema.omit({ id: true });
+
+export const FactTypeUpdateSchema = FactTypeSchema.pick({ id: true }).merge(
+  FactTypeSchema.omit({ id: true }).partial(),
+);
 
 export const FactTypesResponseSchema = z.object({
   data: z.array(FactTypeSchema),
@@ -53,6 +38,7 @@ export const FactTypeResponseSchema = z.object({
 });
 
 export type FactTypeType = z.infer<typeof FactTypeSchema>;
+export type FactTypeNewType = z.infer<typeof FactTypeUpdateSchema>;
 export type FactTypeUpdateType = z.infer<typeof FactTypeUpdateSchema>;
 export type FactTypesResponseType = z.infer<typeof FactTypesResponseSchema>;
 export type FactTypeResponseType = z.infer<typeof FactTypeResponseSchema>;
@@ -61,10 +47,10 @@ export const deserializeFactType = (data: FactTypeType): FactTypeModel => {
   return new FactTypeModel(data);
 };
 
-export const serializeFactType = (data: FactTypeModel): FactTypeType => {
-  return {
-    ...data,
-    createdAt: data.createdAt ? data.createdAt.toISO() : undefined,
-    updatedAt: data.updatedAt ? data.updatedAt.toISO() : undefined,
-  };
-};
+// export const serializeFactType = (data: FactTypeModel): FactTypeType => {
+//   return {
+//     ...data,
+//     createdAt: data.createdAt ? data.createdAt.toISO() : undefined,
+//     updatedAt: data.updatedAt ? data.updatedAt.toISO() : undefined,
+//   };
+// };

--- a/packages/admin/src/app/shared/schemas/fact.schema.ts
+++ b/packages/admin/src/app/shared/schemas/fact.schema.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 import { FactModel } from '@shared/models/fact.model';
-import { UserSchema } from '@shared/schemas/user.schema';
 import { FactTypeSchema } from './fact-type.schema';
-import { TagSchema } from '@schemas/tag.schema';
 import { PersonSchema } from '@schemas/person.schema';
 import { EventSchema } from '@schemas/event.schema';
 import { ResourceSchema } from '@schemas/resource.schema';
@@ -20,7 +18,7 @@ export const FactSchema: any = z
     eventId: z.string().uuid().optional().nullable(),
     observedAt: z.string().datetime({ offset: true }).optional().nullable(),
     dimensions: z.array(DimensionSchema).optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     factType: z.lazy(() => FactTypeSchema.optional()),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),
@@ -39,7 +37,7 @@ export const FactUpdateSchema = FactSchema.extend({
   eventId: z.string().uuid().optional().nullable(),
   observedAt: z.string().datetime({ offset: true }).optional().nullable(),
   dimensions: z.array(DimensionSchema).optional().nullable(),
-  tags: z.lazy(() => z.array(TagSchema).optional()),
+  tags: z.array(z.string()).optional(),
   factType: z.lazy(() => FactTypeSchema.optional()),
   createdAt: z.string().datetime({ offset: true }).optional(),
   updatedAt: z.string().datetime({ offset: true }).optional(),

--- a/packages/admin/src/app/shared/schemas/person-type.schema.ts
+++ b/packages/admin/src/app/shared/schemas/person-type.schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { PersonSchema } from './person.schema';
 import { PersonTypeModel } from '../models/person-type.model';
-import { TagSchema } from '@schemas/tag.schema';
 
 export const PersonTypeSchema = z
   .object({
@@ -9,7 +8,7 @@ export const PersonTypeSchema = z
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     people: z.array(PersonSchema).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),
@@ -22,7 +21,7 @@ export const PersonTypeUpdateSchema = z
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     people: z.array(PersonSchema).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),

--- a/packages/admin/src/app/shared/schemas/person.schema.ts
+++ b/packages/admin/src/app/shared/schemas/person.schema.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import { PersonModel } from '@shared/models/person.model';
 import { UserSchema } from '@shared/schemas/user.schema';
 import { PersonTypeSchema } from './person-type.schema';
-import { TagSchema } from '@schemas/tag.schema';
 import { CohortSchema } from './cohort.schema';
 
 export const PersonSchema: any = z
@@ -11,7 +10,7 @@ export const PersonSchema: any = z
     familyName: z.string(),
     givenName: z.string(),
     typeKey: z.string(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     user: z.lazy(() => UserSchema.optional().nullable()),
     personType: PersonTypeSchema.optional(),
     cohorts: z.lazy(() => z.array(CohortSchema).optional()),
@@ -27,7 +26,7 @@ export const PersonUpdateSchema = PersonSchema.extend({
   familyName: z.string().optional(),
   givenName: z.string().optional(),
   typeKey: z.string().optional(),
-  tags: z.lazy(() => z.array(TagSchema).optional()),
+  tags: z.array(z.string()).optional(),
   createdAt: z.string().datetime({ offset: true }).optional(),
   updatedAt: z.string().datetime({ offset: true }).optional(),
 }).strict();

--- a/packages/admin/src/app/shared/schemas/resource-type.schema.ts
+++ b/packages/admin/src/app/shared/schemas/resource-type.schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { ResourceSchema } from './resource.schema';
 import { ResourceTypeModel } from '../models/resource-type.model';
-import { TagSchema } from '@schemas/tag.schema';
 
 export const ResourceTypeSchema: any = z
   .object({
@@ -9,7 +8,7 @@ export const ResourceTypeSchema: any = z
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     resources: z.array(ResourceSchema).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),
@@ -22,7 +21,7 @@ export const ResourceTypeUpdateSchema = z
     key: z.string(),
     name: z.string(),
     description: z.string().optional().nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     resources: z.array(ResourceSchema).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),

--- a/packages/admin/src/app/shared/schemas/resource.schema.ts
+++ b/packages/admin/src/app/shared/schemas/resource.schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { TagSchema } from './tag.schema';
 import { ResourceModel } from '../models/resource.model';
 import { ResourceTypeSchema } from './resource-type.schema';
 
@@ -10,7 +9,7 @@ export const ResourceSchema: any = z
     info: z.object({}).passthrough(),
     typeKey: z.string(),
     resourceType: ResourceTypeSchema.optional(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     createdAt: z.string().datetime({ offset: true }).optional(),
     updatedAt: z.string().datetime({ offset: true }).optional(),
   })
@@ -20,7 +19,7 @@ export const ResourceUpdateSchema = ResourceSchema.extend({
   id: z.string().uuid(),
   name: z.string().optional(),
   typeKey: z.string().optional(),
-  tags: z.lazy(() => z.array(TagSchema).optional()),
+  tags: z.array(z.string()).optional(),
   info: z.object({}).passthrough().optional(),
   createdAt: z.string().datetime({ offset: true }).optional(),
   updatedAt: z.string().datetime({ offset: true }).optional(),

--- a/packages/admin/src/app/shared/schemas/user.schema.ts
+++ b/packages/admin/src/app/shared/schemas/user.schema.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import { UserModel } from '@shared/models';
 import { RoleSchema } from './role.schema';
 import { PersonSchema } from '@shared/schemas/person.schema';
-import { TagSchema } from '@schemas/tag.schema';
 
 // validate data coming from API or sending to API for create
 // TODO: Do we want to have both request and response schemas?  Or do we want to make some fields optional?
@@ -19,7 +18,7 @@ export const UserSchema: any = z
       .lazy(() => PersonSchema)
       .optional()
       .nullable(),
-    tags: z.lazy(() => z.array(TagSchema).optional()),
+    tags: z.array(z.string()).optional(),
     passwordResetCode: z.string().optional().nullable(),
     requiresPasswordChange: z.boolean().optional().nullable(),
   })

--- a/packages/server/app/controllers/events_controller.ts
+++ b/packages/server/app/controllers/events_controller.ts
@@ -78,8 +78,15 @@ export default class EventsController {
   async store({ request, auth }: HttpContext) {
     await auth.authenticate()
     await request.validateUsing(createEventValidator)
-    const cleanRequest = request.only(['typeKey', 'startedAt', 'endedAt', 'personId', 'resourceId', 'tags'])
-    let newEvent = null;
+    const cleanRequest = request.only([
+      'typeKey',
+      'startedAt',
+      'endedAt',
+      'personId',
+      'resourceId',
+      'tags',
+    ])
+    let newEvent = null
 
     await db.transaction(async (trx) => {
       newEvent = new Event().fill(cleanRequest).useTransaction(trx)
@@ -155,7 +162,14 @@ export default class EventsController {
     await request.validateUsing(updateEventValidator)
     await paramsUUIDValidator.validate(params)
     // TODO Add person/personId and resource/resourceId when implemented
-    const cleanRequest = request.only(['typeKey', 'startedAt', 'endedAt', 'personId', 'resourceId'])
+    const cleanRequest = request.only([
+      'typeKey',
+      'startedAt',
+      'endedAt',
+      'personId',
+      'resourceId',
+      'tags',
+    ])
     let updatedEvent = null
     await db.transaction(async (trx) => {
       const event = await Event.findOrFail(params.id)

--- a/packages/server/app/controllers/facts_controller.ts
+++ b/packages/server/app/controllers/facts_controller.ts
@@ -134,10 +134,14 @@ export default class FactsController {
    */
   async update({ params, request, auth }: HttpContext) {
     await auth.authenticate()
-    await request.validateUsing(updateFactValidator)
+
+    console.log('#######################request=', request.serialize())
+    const cleanRequest = await request.validateUsing(updateFactValidator)
+
+    console.log('#######################showMeTheMoney=', cleanRequest)
 
     await paramsUUIDValidator.validate(params)
-    const cleanRequest = request.only(['typeKey', 'observedAt', 'dimensions', 'tags'])
+    // const cleanRequest = request.only(['typeKey', 'observedAt', 'dimensions', 'tags'])
     let updatedFact = null
     await db.transaction(async (trx) => {
       const fact = await Fact.findOrFail(params.id)

--- a/packages/server/app/helpers/query_builder.ts
+++ b/packages/server/app/helpers/query_builder.ts
@@ -171,7 +171,7 @@ export async function setTagsForObject(
   objectId: string,
   objectType: string,
   tags: string[],
-  isUpdate: boolean = true,
+  isUpdate: boolean = true
 ) {
   if (isUpdate) {
     // Only delete all existing tags on update. For create request, this is unnecessary.

--- a/packages/server/app/models/aw_base_model.ts
+++ b/packages/server/app/models/aw_base_model.ts
@@ -1,0 +1,18 @@
+import Tag from '#models/tag'
+import { BaseModel } from '@adonisjs/lucid/orm'
+import { ModelObject } from '@adonisjs/lucid/types/model'
+
+export default class AwBaseModel extends BaseModel {
+  // Override the serialize method
+  serialize(cherryPick?: ModelObject): any {
+    // Get the default serialized data
+    const serialized = super.serialize(cherryPick)
+
+    // Check if 'tags' property exists and transform it
+    if ('tags' in serialized && Array.isArray(serialized.tags)) {
+      serialized.tags = serialized.tags.map((tag: Tag) => tag.pathname)
+    }
+
+    return serialized
+  }
+}

--- a/packages/server/app/models/cohort.ts
+++ b/packages/server/app/models/cohort.ts
@@ -1,10 +1,11 @@
 import { DateTime } from 'luxon'
-import { afterDelete, BaseModel, column, manyToMany } from '@adonisjs/lucid/orm'
+import { afterDelete, column, manyToMany } from '@adonisjs/lucid/orm'
 import Person from '#models/person'
 import type { ManyToMany } from '@adonisjs/lucid/types/relations'
 import Tag from '#models/tag'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Cohort extends BaseModel {
+export default class Cohort extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/dimension.ts
+++ b/packages/server/app/models/dimension.ts
@@ -1,12 +1,9 @@
-import { column } from '@adonisjs/lucid/orm'
-
 export default class Dimension {
-  @column()
-  declare key: string
+  key: string
+  value: string
 
-  @column()
-  declare value: string
-
-  @column()
-  declare factId: string
+  constructor(key: string, value: string) {
+    this.key = key
+    this.value = value
+  }
 }

--- a/packages/server/app/models/dimension_schema.ts
+++ b/packages/server/app/models/dimension_schema.ts
@@ -1,18 +1,21 @@
-import { column } from '@adonisjs/lucid/orm'
-
 export default class DimensionSchema {
-  @column()
-  declare key: string
+  key: string
+  name: string
+  dataType: string
+  dataUnit: string | null
+  isRequired: boolean
 
-  @column()
-  declare name: string
-
-  @column()
-  declare dataType: string
-
-  @column()
-  declare dataUnit: string | null
-
-  @column()
-  declare isRequired: boolean
+  constructor(
+    key: string,
+    name: string,
+    dataType: string,
+    dataUnit: string,
+    isRequired: boolean = true
+  ) {
+    this.key = key
+    this.name = name
+    this.dataType = dataType
+    this.dataUnit = dataUnit
+    this.isRequired = isRequired
+  }
 }

--- a/packages/server/app/models/event.ts
+++ b/packages/server/app/models/event.ts
@@ -1,13 +1,14 @@
 import { DateTime } from 'luxon'
-import { afterDelete, BaseModel, belongsTo, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
+import { afterDelete, belongsTo, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import type { BelongsTo, HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import EventType from '#models/event_type'
 import Fact from '#models/fact'
 import Tag from '#models/tag'
 import Person from '#models/person'
 import Resource from '#models/resource'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Event extends BaseModel {
+export default class Event extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/event_type.ts
+++ b/packages/server/app/models/event_type.ts
@@ -1,18 +1,12 @@
 import { DateTime } from 'luxon'
-import {
-  afterDelete,
-  BaseModel,
-  beforeSave,
-  column,
-  hasMany,
-  manyToMany,
-} from '@adonisjs/lucid/orm'
+import { afterDelete, beforeSave, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import type { HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Event from '#models/event'
 import Tag from '#models/tag'
 import { generateTypeKey } from '#helpers/generate_type_key'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class EventType extends BaseModel {
+export default class EventType extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/fact.ts
+++ b/packages/server/app/models/fact.ts
@@ -1,12 +1,5 @@
 import { DateTime } from 'luxon'
-import {
-  afterDelete,
-  BaseModel,
-  beforeSave,
-  belongsTo,
-  column,
-  manyToMany,
-} from '@adonisjs/lucid/orm'
+import { afterDelete, beforeSave, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
 import FactType from '#models/fact_type'
 import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Person from '#models/person'
@@ -14,8 +7,9 @@ import Resource from '#models/resource'
 import Event from '#models/event'
 import Tag from '#models/tag'
 import Dimension from '#models/dimension'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Fact extends BaseModel {
+export default class Fact extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/fact_type.ts
+++ b/packages/server/app/models/fact_type.ts
@@ -1,19 +1,13 @@
 import { DateTime } from 'luxon'
-import {
-  afterDelete,
-  BaseModel,
-  beforeSave,
-  column,
-  hasMany,
-  manyToMany,
-} from '@adonisjs/lucid/orm'
+import { afterDelete, beforeSave, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import type { HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Fact from '#models/fact'
 import Tag from '#models/tag'
 import { generateTypeKey } from '#helpers/generate_type_key'
 import DimensionSchema from '#models/dimension_schema'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class FactType extends BaseModel {
+export default class FactType extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/person.ts
+++ b/packages/server/app/models/person.ts
@@ -1,13 +1,5 @@
 import { DateTime } from 'luxon'
-import {
-  afterDelete,
-  BaseModel,
-  belongsTo,
-  column,
-  hasMany,
-  hasOne,
-  manyToMany,
-} from '@adonisjs/lucid/orm'
+import { afterDelete, belongsTo, column, hasMany, hasOne, manyToMany } from '@adonisjs/lucid/orm'
 import User from '#models/user'
 import type { BelongsTo, HasMany, HasOne, ManyToMany } from '@adonisjs/lucid/types/relations'
 import PersonType from '#models/person_type'
@@ -15,8 +7,9 @@ import Fact from '#models/fact'
 import Cohort from '#models/cohort'
 import Tag from '#models/tag'
 import Event from '#models/event'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Person extends BaseModel {
+export default class Person extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/person_type.ts
+++ b/packages/server/app/models/person_type.ts
@@ -1,18 +1,12 @@
 import { DateTime } from 'luxon'
-import {
-  afterDelete,
-  BaseModel,
-  beforeSave,
-  column,
-  hasMany,
-  manyToMany,
-} from '@adonisjs/lucid/orm'
+import { afterDelete, beforeSave, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import type { HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Person from '#models/person'
 import Tag from '#models/tag'
 import { generateTypeKey } from '#helpers/generate_type_key'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class PersonType extends BaseModel {
+export default class PersonType extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/policy.ts
+++ b/packages/server/app/models/policy.ts
@@ -1,9 +1,10 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, manyToMany } from '@adonisjs/lucid/orm'
+import { column, manyToMany } from '@adonisjs/lucid/orm'
 import type { ManyToMany } from '@adonisjs/lucid/types/relations'
 import Role from '#models/role'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Policy extends BaseModel {
+export default class Policy extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: number
 

--- a/packages/server/app/models/resource.ts
+++ b/packages/server/app/models/resource.ts
@@ -1,12 +1,13 @@
 import { DateTime } from 'luxon'
-import { afterDelete, BaseModel, belongsTo, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
+import { afterDelete, belongsTo, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import ResourceType from '#models/resource_type'
 import type { BelongsTo, HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Fact from '#models/fact'
 import Tag from '#models/tag'
 import Event from '#models/event'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Resource extends BaseModel {
+export default class Resource extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/resource_type.ts
+++ b/packages/server/app/models/resource_type.ts
@@ -1,18 +1,12 @@
 import { DateTime } from 'luxon'
-import {
-  afterDelete,
-  BaseModel,
-  beforeSave,
-  column,
-  hasMany,
-  manyToMany,
-} from '@adonisjs/lucid/orm'
+import { afterDelete, beforeSave, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import Resource from '#models/resource'
 import type { HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Tag from '#models/tag'
 import { generateTypeKey } from '#helpers/generate_type_key'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class ResourceType extends BaseModel {
+export default class ResourceType extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/role.ts
+++ b/packages/server/app/models/role.ts
@@ -1,10 +1,11 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
+import { column, hasMany, manyToMany } from '@adonisjs/lucid/orm'
 import User from '#models/user'
 import type { HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Policy from '#models/policy'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Role extends BaseModel {
+export default class Role extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/tag.ts
+++ b/packages/server/app/models/tag.ts
@@ -1,13 +1,14 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, manyToMany } from '@adonisjs/lucid/orm'
+import { column, manyToMany } from '@adonisjs/lucid/orm'
 import type { ManyToMany } from '@adonisjs/lucid/types/relations'
 import Event from '#models/event'
 import Person from '#models/person'
 import Resource from '#models/resource'
 import Fact from '#models/fact'
 import User from '#models/user'
+import AwBaseModel from '#models/aw_base_model'
 
-export default class Tag extends BaseModel {
+export default class Tag extends AwBaseModel {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/models/user.ts
+++ b/packages/server/app/models/user.ts
@@ -1,20 +1,21 @@
 import { DateTime } from 'luxon'
 import hash from '@adonisjs/core/services/hash'
 import { compose } from '@adonisjs/core/helpers'
-import { afterDelete, BaseModel, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
+import { afterDelete, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
 import { withAuthFinder } from '@adonisjs/auth/mixins/lucid'
 import { DbAccessTokensProvider } from '@adonisjs/auth/access_tokens'
 import Role from '#models/role'
 import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Person from '#models/person'
 import Tag from '#models/tag'
+import AwBaseModel from '#models/aw_base_model'
 
 const AuthFinder = withAuthFinder(() => hash.use('scrypt'), {
   uids: ['email'],
   passwordColumnName: 'password',
 })
 
-export default class User extends compose(BaseModel, AuthFinder) {
+export default class User extends compose(AwBaseModel, AuthFinder) {
   @column({ isPrimary: true })
   declare id: string
 

--- a/packages/server/app/validators/cohort.ts
+++ b/packages/server/app/validators/cohort.ts
@@ -29,5 +29,5 @@ export const updateCohortValidator = vine.compile(
  * Validates the people ids for the cohort's attachPeople, detachPeople and setPeople action
  */
 export const peopleIdsValidator = vine.compile(
-  vine.object({ peopleIds: vine.array(vine.string().trim().uuid()).distinct() })
+  vine.object({ peopleIds: vine.array(vine.string().uuid()).distinct() })
 )

--- a/packages/server/app/validators/common.ts
+++ b/packages/server/app/validators/common.ts
@@ -5,14 +5,14 @@ import vine from '@vinejs/vine'
  */
 export const paramsUUIDValidator = vine.compile(
   vine.object({
-    id: vine.string().trim().uuid(),
+    id: vine.string().uuid(),
   })
 )
 
 export const paramsTripleObjectUUIDValidator = vine.compile(
   vine.object({
-    person_id: vine.string().trim().uuid().optional().nullable(),
-    resource_id: vine.string().trim().uuid().optional().nullable(),
-    event_id: vine.string().trim().uuid().optional().nullable(),
+    person_id: vine.string().uuid().optional().nullable(),
+    resource_id: vine.string().uuid().optional().nullable(),
+    event_id: vine.string().uuid().optional().nullable(),
   })
 )

--- a/packages/server/app/validators/fact.ts
+++ b/packages/server/app/validators/fact.ts
@@ -1,6 +1,9 @@
 import vine from '@vinejs/vine'
+import { DateTime } from 'luxon'
 
-export const dimensions = vine.array(vine.object({ key: vine.string(), value: vine.any() }))
+export const dimensions = vine.array(
+  vine.object({ key: vine.string(), value: vine.any() }).optional()
+)
 
 /**
  * Validates the fact's create action
@@ -10,7 +13,7 @@ export const createFactValidator = vine.compile(
     typeKey: vine.string().trim(),
     observedAt: vine.date({ formats: { utc: true } }).optional(),
     info: vine.object({}).allowUnknownProperties().optional(),
-    tags: vine.array(vine.string().trim()).optional(),
+    tags: vine.array(vine.string().optional()).optional(),
     dimensions: dimensions,
   })
 )
@@ -20,10 +23,13 @@ export const createFactValidator = vine.compile(
  */
 export const updateFactValidator = vine.compile(
   vine.object({
-    id: vine.string().trim().uuid(),
-    typeKey: vine.string().trim().optional(),
-    observedAt: vine.date({ formats: { utc: true } }).optional(),
-    dimensions: dimensions,
+    typeKey: vine.string().optional(),
+    observedAt: vine
+      .string()
+      .transform((value) => DateTime.fromISO(value))
+      .optional(),
+    // observedAt: vine.date({ formats: { utc: true } }).optional(),
+    dimensions: dimensions.optional(),
     tags: vine.array(vine.string().trim()).optional(),
   })
 )
@@ -31,10 +37,14 @@ export const updateFactValidator = vine.compile(
 export const insertDataFactValidator = vine.compile(
   vine.object({
     typeKey: vine.string().trim(),
-    observedAt: vine.date({ formats: { utc: true } }).optional(),
-    person_id: vine.string().trim().uuid().optional().nullable(),
-    resource_id: vine.string().trim().uuid().optional().nullable(),
-    event_id: vine.string().trim().uuid().optional().nullable(),
+    observedAt: vine
+      .string()
+      .transform((value) => DateTime.fromISO(value))
+      .optional(),
+    // observedAt: vine.date({ formats: { utc: true } }).optional(),
+    person_id: vine.string().uuid().optional().nullable(),
+    resource_id: vine.string().uuid().optional().nullable(),
+    event_id: vine.string().uuid().optional().nullable(),
     dimensions: dimensions,
   })
 )
@@ -42,13 +52,10 @@ export const insertDataFactValidator = vine.compile(
 export const updateDataFactValidator = vine.compile(
   vine.object({
     typeKey: vine.string().trim(),
-    observedAt: vine
-      .date({ formats: { utc: true } })
-      .optional()
-      .optional(),
-    person_id: vine.string().trim().uuid().optional().nullable().optional(),
-    resource_id: vine.string().trim().uuid().optional().nullable().optional(),
-    event_id: vine.string().trim().uuid().optional().nullable().optional(),
+    observedAt: vine.date({ formats: { utc: true } }).optional(),
+    person_id: vine.string().uuid().optional().nullable().optional(),
+    resource_id: vine.string().uuid().optional().nullable().optional(),
+    event_id: vine.string().uuid().optional().nullable().optional(),
     dimensions: dimensions.optional(),
   })
 )

--- a/packages/server/app/validators/fact_type.ts
+++ b/packages/server/app/validators/fact_type.ts
@@ -4,9 +4,9 @@ import vine from '@vinejs/vine'
 const dimensionSchemas = vine.array(
   vine.object({
     key: vine.string().trim(),
-    name: vine.string().trim(),
-    dataType: vine.string().trim(),
-    dataUnit: vine.string().trim().optional(),
+    name: vine.string(),
+    dataType: vine.string(),
+    dataUnit: vine.string().optional(),
     isRequired: vine.boolean(),
   })
 )
@@ -16,7 +16,7 @@ const dimensionSchemas = vine.array(
 export const createFactTypeValidator = vine.compile(
   vine.object({
     key: vine.string().trim().regex(TYPE_KEY_PATTERN).minLength(3).optional(),
-    name: vine.string().trim(),
+    name: vine.string(),
     dimensionSchemas: dimensionSchemas.optional(),
     tags: vine.array(vine.string().trim()).optional(),
   })
@@ -27,9 +27,9 @@ export const createFactTypeValidator = vine.compile(
  */
 export const updateFactTypeValidator = vine.compile(
   vine.object({
-    id: vine.string().trim().uuid(),
+    id: vine.string().uuid(),
     key: vine.string().trim().regex(TYPE_KEY_PATTERN).minLength(3).optional(),
-    name: vine.string().trim().optional(),
+    name: vine.string().optional(),
     dimensionSchemas: dimensionSchemas.optional(),
     tags: vine.array(vine.string().trim()).optional(),
   })

--- a/packages/server/app/validators/person.ts
+++ b/packages/server/app/validators/person.ts
@@ -20,5 +20,5 @@ export const updatePersonValidator = vine.compile(vine.object({}))
  * Validates the cohort ids for the person's attachCohort and detachCohort actions
  */
 export const cohortIdsValidator = vine.compile(
-  vine.object({ cohortIds: vine.array(vine.string().trim().uuid()).distinct() })
+  vine.object({ cohortIds: vine.array(vine.string().uuid()).distinct() })
 )

--- a/packages/server/app/validators/person_type.ts
+++ b/packages/server/app/validators/person_type.ts
@@ -17,7 +17,7 @@ export const createPersonTypeValidator = vine.compile(
  */
 export const updatePersonTypeValidator = vine.compile(
   vine.object({
-    id: vine.string().trim().uuid(),
+    id: vine.string().uuid(),
     name: vine.string().trim().minLength(3),
     key: vine.string().trim().regex(TYPE_KEY_PATTERN).minLength(3).optional(),
     description: vine.string().trim().optional(),

--- a/packages/server/app/validators/resource_type.ts
+++ b/packages/server/app/validators/resource_type.ts
@@ -16,7 +16,7 @@ export const createResourceTypeValidator = vine.compile(
  */
 export const updateResourceTypeValidator = vine.compile(
   vine.object({
-    id: vine.string().trim().uuid(),
+    id: vine.string().uuid(),
     name: vine.string().trim().minLength(3),
     key: vine.string().trim().regex(TYPE_KEY_PATTERN).minLength(3).optional(),
     description: vine.string().trim().optional(),


### PR DESCRIPTION
feature/ARCWELL-419-tag-string-arrays
- Added a new BaseModel that all of our lucid models should extend (AwBaseModel)
- New BaseModel will serialize tags into string arrays
- Update all admin zod validations to accept tags as string arrays
- Updated all component to use tags as string arrays
- WIP review of other validations and models.