### PR TITLE
feature/ARCWELL-275-7-redesign-pass

### DIFF
--- a/packages/admin/src/app/feature/project-management/cohort/cohort.component.html
+++ b/packages/admin/src/app/feature/project-management/cohort/cohort.component.html
@@ -1,125 +1,119 @@
 @if (cohortStore.isReady()) {
-  <div class="table-form-container">
-    <aw-detail-header
-      detailName="Cohort"
-      [inEditMode]="cohortStore.inEditMode()"
-      [inCreateMode]="cohortStore.inCreateMode()"
-      (toggleEditMode)="cohortStore.toggleEditMode()"
-      (delete)="onDelete()"
-    ></aw-detail-header>
+  <aw-detail-header
+    detailName="Cohort"
+    [inEditMode]="cohortStore.inEditMode()"
+    [inCreateMode]="cohortStore.inCreateMode()"
+    (toggleEditMode)="cohortStore.toggleEditMode()"
+    (delete)="onDelete()"
+  ></aw-detail-header>
 
-    <form [formGroup]="cohortForm">
-      @if (cohortStore.isErrored()) {
-        <aw-error-container [errors]="cohortStore.errors()" />
+  <form [formGroup]="cohortForm">
+    @if (cohortStore.isErrored()) {
+      <aw-error-container [errors]="cohortStore.errors()" />
+    }
+
+    <mat-form-field appearance="outline">
+      <mat-label>Name</mat-label>
+      <input matInput placeholder="Name" formControlName="name" />
+      @if (cohortForm.controls.name.hasError('required')) {
+        <mat-error>
+          Name is
+          <strong>required</strong>
+        </mat-error>
       }
+    </mat-form-field>
 
-      <mat-form-field appearance="outline">
-        <mat-label>Name</mat-label>
-        <input matInput placeholder="Name" formControlName="name" />
-        @if (cohortForm.controls.name.hasError('required')) {
-          <mat-error>
-            Name is
-            <strong>required</strong>
-          </mat-error>
-        }
-      </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Description</mat-label>
+      <input matInput placeholder="Description" formControlName="description" />
+    </mat-form-field>
 
-      <mat-form-field appearance="outline">
-        <mat-label>Description</mat-label>
-        <input
-          matInput
-          placeholder="Description"
-          formControlName="description"
-        />
-      </mat-form-field>
+    @if (cohortStore.inCreateMode()) {
+      <aw-tags-form
+        [tags]="cohortStore.tagStrings()"
+        (updateTagsForCreate)="updateTagsForCreate($event)"
+        [inEditMode]="false"
+      ></aw-tags-form>
+    }
 
-      @if (cohortStore.inCreateMode()) {
-        <aw-tags-form
-          [tags]="cohortStore.tagStrings()"
-          (updateTagsForCreate)="updateTagsForCreate($event)"
-          [inEditMode]="false"
-        ></aw-tags-form>
-      }
+    <div class="form-button-container">
+      <button
+        mat-button
+        type="button"
+        (click)="onCancel()"
+        class="default-button"
+        [disabled]="!cohortStore.inEditMode()"
+      >
+        Cancel
+      </button>
+      <button
+        mat-flat-button
+        type="submit"
+        class="default-button"
+        [disabled]="
+          !cohortStore.inEditMode() || !cohortForm.valid || !cohortForm.dirty
+        "
+      >
+        Save
+      </button>
+    </div>
+  </form>
 
-      <div class="form-button-container">
-        <button
-          mat-button
-          type="button"
-          (click)="onCancel()"
-          class="default-button"
-          [disabled]="!cohortStore.inEditMode()"
-        >
-          Cancel
-        </button>
+  @if (!cohortStore.inCreateMode()) {
+    <!-- People Section -->
+    <h5 class="card-title">People</h5>
+    <form [formGroup]="peopleForm">
+      <aw-object-selector-form-field
+        formControlName="person"
+        placeholder="Search for Person"
+        label="Person"
+        objectType="cohortPeople"
+        displayProperty="familyName"
+        [objectIdForFiltering]="this.cohortStore.id()"
+        [objectSubTypes]="this.cohortStore.personTypes()"
+      ></aw-object-selector-form-field>
+
+      <div class="icons-container">
         <button
           mat-flat-button
           type="submit"
           class="default-button"
           [disabled]="
-            !cohortStore.inEditMode() || !cohortForm.valid || !cohortForm.dirty
+            cohortStore.inEditMode() || !peopleForm.valid || !peopleForm.dirty
           "
         >
-          Save
+          Add Person to Cohort
         </button>
       </div>
     </form>
 
-    @if (!cohortStore.inCreateMode()) {
-      <!-- People Section -->
-      <h5 class="card-title">People</h5>
-      <form [formGroup]="peopleForm">
-        <aw-object-selector-form-field
-          formControlName="person"
-          placeholder="Search for Person"
-          label="Person"
-          objectType="cohortPeople"
-          displayProperty="familyName"
-          [objectIdForFiltering]="this.cohortStore.id()"
-          [objectSubTypes]="this.cohortStore.personTypes()"
-        ></aw-object-selector-form-field>
-
-        <div class="icons-container">
-          <button
-            mat-flat-button
-            type="submit"
-            class="default-button"
-            [disabled]="
-              cohortStore.inEditMode() || !peopleForm.valid || !peopleForm.dirty
-            "
-          >
-            Add Person to Cohort
-          </button>
-        </div>
-      </form>
-
-      @if (cohortStore.peopleCount() > 0) {
-        <aw-people-table
-          [dataSource]="peopleDataSource"
-          [displayedColumns]="peopleColumns"
-          [matSortActive]="this.cohortStore.peopleListOptions().sort"
-          [matSortDirection]="this.cohortStore.peopleListOptions().order"
-          [length]="this.cohortStore.peopleCount()"
-          [pageSizes]="pageSizes"
-          [pageSize]="this.cohortStore.peopleListOptions().limit"
-          [pageIndex]="this.cohortStore.peopleListOptions().pageIndex"
-          (onDeleteClicked)="peopleDeleteClick($event)"
-          (onPageChanged)="peoplePageChange($event)"
-          (onRowClicked)="peopleRowClick($event)"
-          (onSortChanged)="peopleSortChange($event)"
-        ></aw-people-table>
-      } @else {
-        <h5 class="no-people card-title">
-          No persons currently associated with this cohort
-        </h5>
-      }
-
-      @if (!cohortStore.inCreateMode()) {
-        <!--  Tags Section-->
-        <aw-tags-form
-          [tags]="cohortStore.tagStrings()"
-          (saveTags)="onSetTags($event)"
-        ></aw-tags-form>
-      }
+    @if (cohortStore.peopleCount() > 0) {
+      <aw-people-table
+        [dataSource]="peopleDataSource"
+        [displayedColumns]="peopleColumns"
+        [matSortActive]="this.cohortStore.peopleListOptions().sort"
+        [matSortDirection]="this.cohortStore.peopleListOptions().order"
+        [length]="this.cohortStore.peopleCount()"
+        [pageSizes]="pageSizes"
+        [pageSize]="this.cohortStore.peopleListOptions().limit"
+        [pageIndex]="this.cohortStore.peopleListOptions().pageIndex"
+        (onDeleteClicked)="peopleDeleteClick($event)"
+        (onPageChanged)="peoplePageChange($event)"
+        (onRowClicked)="peopleRowClick($event)"
+        (onSortChanged)="peopleSortChange($event)"
+      ></aw-people-table>
+    } @else {
+      <h5 class="no-people card-title">
+        No persons currently associated with this cohort
+      </h5>
     }
-  </div>
+
+    @if (!cohortStore.inCreateMode()) {
+      <!--  Tags Section-->
+      <aw-tags-form
+        [tags]="cohortStore.tagStrings()"
+        (saveTags)="onSetTags($event)"
+      ></aw-tags-form>
+    }
+  }
 }

--- a/packages/admin/src/app/feature/project-management/cohort/cohort.store.ts
+++ b/packages/admin/src/app/feature/project-management/cohort/cohort.store.ts
@@ -230,6 +230,11 @@ export const CohortStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
       async loadPeoplePage(props: {

--- a/packages/admin/src/app/feature/project-management/detail/detail.component.ts
+++ b/packages/admin/src/app/feature/project-management/detail/detail.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   Type,
   ViewContainerRef,
+  effect,
   inject,
   input,
 } from '@angular/core';
@@ -43,7 +44,7 @@ export type DetailComponentType =
   templateUrl: './detail.component.html',
   styleUrl: './detail.component.scss',
 })
-export class DetailComponent implements AfterViewInit, OnDestroy {
+export class DetailComponent implements OnDestroy {
   private viewContainer = inject(ViewContainerRef);
   faTimes = faTimes;
   detailId = input.required<string>();
@@ -51,23 +52,27 @@ export class DetailComponent implements AfterViewInit, OnDestroy {
   typeKey = input<string>();
   private componentRef!: ComponentRef<DetailComponentType>;
 
-  ngAfterViewInit() {
+  constructor() {
     // dynamically create the detail component and set inputs
-    const component = this.detailComponent();
-    if (component) {
-      this.viewContainer.clear();
-      this.componentRef = this.viewContainer.createComponent(component);
+    effect(() => {
+      if (this.detailComponent() !== null) {
+        const component = this.detailComponent();
+        if (component) {
+          this.viewContainer.clear();
+          this.componentRef = this.viewContainer.createComponent(component);
 
-      if (this.detailId() !== undefined) {
-        this.componentRef.instance.detailId = this.detailId();
+          if (this.detailId() !== undefined) {
+            this.componentRef.instance.detailId = this.detailId();
+          }
+          if (
+            this.typeKey() !== undefined &&
+            'typeKey' in this.componentRef.instance
+          ) {
+            this.componentRef.instance.typeKey = this.typeKey();
+          }
+        }
       }
-      if (
-        this.typeKey() !== undefined &&
-        'typeKey' in this.componentRef.instance
-      ) {
-        this.componentRef.instance.typeKey = this.typeKey();
-      }
-    }
+    });
   }
 
   ngOnDestroy() {

--- a/packages/admin/src/app/feature/project-management/event-type/event-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/event-type/event-type.store.ts
@@ -164,6 +164,11 @@ export const EventTypeStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/feature/project-management/event/event.store.ts
+++ b/packages/admin/src/app/feature/project-management/event/event.store.ts
@@ -240,6 +240,11 @@ export const EventStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/feature/project-management/fact-type/fact-type.component.html
+++ b/packages/admin/src/app/feature/project-management/fact-type/fact-type.component.html
@@ -44,7 +44,7 @@
       <table
         mat-table
         [dataSource]="factTypeStore.factType().dimensionSchemas"
-        class="mat-elevation-z8"
+        class="mat-elevation-z0"
       >
         <ng-container matColumnDef="key">
           <th mat-header-cell *matHeaderCellDef>Key</th>

--- a/packages/admin/src/app/feature/project-management/fact-type/fact-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/fact-type/fact-type.store.ts
@@ -158,6 +158,11 @@ export const FactTypeStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/feature/project-management/fact/fact.component.html
+++ b/packages/admin/src/app/feature/project-management/fact/fact.component.html
@@ -69,7 +69,9 @@
       [objectSubTypes]="this.factStore.resourceTypes()"
     ></aw-object-selector-form-field>
 
-    <h6>Note: Currently, events can only be added via the api</h6>
+    <div class="body-large">
+      Note: Currently, events can only be added via the api
+    </div>
     <!--    <aw-object-selector-form-field-->
     <!--      formControlName="event"-->
     <!--      placeholder="Search for Event"-->
@@ -83,7 +85,7 @@
       <table
         mat-table
         [dataSource]="factStore.fact().dimensions"
-        class="mat-elevation-z8"
+        class="mat-elevation-z0"
       >
         <ng-container matColumnDef="key">
           <th mat-header-cell *matHeaderCellDef>Key</th>
@@ -114,11 +116,11 @@
           </mat-error>
         }
       </mat-form-field>
-      <h6>
+      <div class="body-large">
         Note: Dimensions will not be validated by the fact type's dimension
         schema. Use with extreme caution. Suggested fact creation is done via
         the data insert api.
-      </h6>
+      </div>
     }
 
     @if (factStore.inCreateMode()) {

--- a/packages/admin/src/app/feature/project-management/fact/fact.store.ts
+++ b/packages/admin/src/app/feature/project-management/fact/fact.store.ts
@@ -232,10 +232,14 @@ export const FactStore = signalStore(
         );
         if (resp && resp.errors) {
           patchState(store, setErrors(resp.errors));
-          toastService.sendMessage('Error setting facts.', ToastLevel.ERROR);
+          toastService.sendMessage('Error setting tags.', ToastLevel.ERROR);
         } else {
           patchState(store, setFulfilled());
-          toastService.sendMessage('Set facts.', ToastLevel.SUCCESS);
+
+          toastService.sendMessage('Tags Set', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/feature/project-management/person-type/person-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/person-type/person-type.store.ts
@@ -166,6 +166,11 @@ export const PersonTypeStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/feature/project-management/person/person.component.html
+++ b/packages/admin/src/app/feature/project-management/person/person.component.html
@@ -113,17 +113,19 @@
     </form>
 
     @if (personStore.person().cohortsCount > 0) {
-      <aw-cohort-table
-        [dataSource]="cohortsDataSource"
-        [displayedColumns]="cohortColumns"
-        [length]="this.personStore.person().cohortsCount"
-        [pageSizes]="pageSizes"
-        [pageSize]="this.personStore.cohortsListOptions().limit"
-        [pageIndex]="this.personStore.cohortsListOptions().pageIndex"
-        (onDeleteClicked)="cohortsDeleteClick($event)"
-        (onPageChanged)="cohortsPageChange($event)"
-        (onRowClicked)="cohortsRowClick($event)"
-      ></aw-cohort-table>
+      <div class="table-form-container">
+        <aw-cohort-table
+          [dataSource]="cohortsDataSource"
+          [displayedColumns]="cohortColumns"
+          [length]="this.personStore.person().cohortsCount"
+          [pageSizes]="pageSizes"
+          [pageSize]="this.personStore.cohortsListOptions().limit"
+          [pageIndex]="this.personStore.cohortsListOptions().pageIndex"
+          (onDeleteClicked)="cohortsDeleteClick($event)"
+          (onPageChanged)="cohortsPageChange($event)"
+          (onRowClicked)="cohortsRowClick($event)"
+        ></aw-cohort-table>
+      </div>
     } @else {
       <div class="body-large">
         No cohorts currently associated with this person

--- a/packages/admin/src/app/feature/project-management/person/person.store.ts
+++ b/packages/admin/src/app/feature/project-management/person/person.store.ts
@@ -221,6 +221,11 @@ export const PersonStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
       async loadCohortsPage(limit: number, offset: number, pageIndex: number) {

--- a/packages/admin/src/app/feature/project-management/project-management.component.ts
+++ b/packages/admin/src/app/feature/project-management/project-management.component.ts
@@ -58,7 +58,7 @@ export class ProjectManagementComponent implements AfterViewInit {
       if (event instanceof NavigationEnd) {
         // get the detail_id queryparam from the url
         const { detail_id } = this.activatedRoute.snapshot.queryParams;
-        this.detailId.set(detail_id || '');
+        this.detailId.update(() => detail_id || '');
 
         // get the type_key from childs url params
         const urlParams = this.activatedRoute.firstChild?.snapshot?.params;
@@ -72,7 +72,8 @@ export class ProjectManagementComponent implements AfterViewInit {
           this.activatedRoute.snapshot.firstChild?.firstChild?.firstChild?.data[
             'detailComponent'
           ];
-        this.detailComponent.set(detailComponent || null);
+
+        this.detailComponent.update(() => detailComponent || null);
 
         // set the drawerOpen based on the presence of the detail_id queryparam
         this.detailStore.setDrawerOpen(

--- a/packages/admin/src/app/feature/project-management/resource-type/resource-type.store.ts
+++ b/packages/admin/src/app/feature/project-management/resource-type/resource-type.store.ts
@@ -178,6 +178,11 @@ export const ResourceTypeStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/feature/project-management/resource/resource.store.ts
+++ b/packages/admin/src/app/feature/project-management/resource/resource.store.ts
@@ -197,6 +197,11 @@ export const ResourceStore = signalStore(
           patchState(store, setErrors(resp.errors));
         } else {
           patchState(store, setFulfilled());
+
+          toastService.sendMessage('Tags updated.', ToastLevel.SUCCESS);
+
+          // refresh the list
+          refreshService.triggerRefresh();
         }
       },
     }),

--- a/packages/admin/src/app/shared/components/config-bar/config-bar.component.html
+++ b/packages/admin/src/app/shared/components/config-bar/config-bar.component.html
@@ -1,6 +1,6 @@
 <div class="config-bar-container">
-  <h5 class="config-name-title">
+  <h6 class="config-name-title font-weight-light">
     {{ configStore.config()?.arcwell?.name }}
-  </h5>
+  </h6>
   <mat-divider class="config-bar-divider"></mat-divider>
 </div>

--- a/packages/admin/src/app/shared/components/table-header/table-header.component.html
+++ b/packages/admin/src/app/shared/components/table-header/table-header.component.html
@@ -1,13 +1,13 @@
 <div class="main-container-header">
-  <h3>
+  <h4 class="font-weight-light">
     {{ tableName() }}
-  </h3>
+  </h4>
   <div class="icons-container">
     <button
       mat-button
       (click)="onCreate()"
       matTooltip="Add new"
-      class="table-header-button label-large font-weight-regular"
+      class="table-header-button label-medium font-weight-regular"
     >
       <fa-icon
         aria-label="Add new icon button"
@@ -20,7 +20,7 @@
     <button
       mat-button
       matTooltip="Filter"
-      class="table-header-button label-large font-weight-regular"
+      class="table-header-button label-medium font-weight-regular"
     >
       <fa-icon
         aria-label="Filter icon button"
@@ -33,7 +33,7 @@
     <button
       mat-button
       matTooltip="Search"
-      class="table-header-button label-large font-weight-regular"
+      class="table-header-button label-medium font-weight-regular"
     >
       <fa-icon
         aria-label="Search icon button"

--- a/packages/admin/src/app/shared/components/table-header/table-header.component.scss
+++ b/packages/admin/src/app/shared/components/table-header/table-header.component.scss
@@ -1,9 +1,5 @@
 @use 'colors' as colors;
 
-h4 {
-  margin: 0;
-}
-
 .main-container-header {
   display: flex;
   flex-direction: row;
@@ -13,6 +9,7 @@ h4 {
   .icons-container {
     display: flex;
     gap: 30px;
+    margin-bottom: 15px;
   }
 
   .table-header-button {

--- a/packages/admin/src/app/shared/components/tags-form/tags-form.component.ts
+++ b/packages/admin/src/app/shared/components/tags-form/tags-form.component.ts
@@ -34,6 +34,7 @@ import { ConfirmationDialogComponent } from '@shared/components/dialogs/confirma
 import { MatDialog } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
 import { MatInputModule } from '@angular/material/input';
+import { DetailStore } from '@app/feature/project-management/detail/detail.store';
 
 @Component({
   selector: 'aw-tags-form',
@@ -60,6 +61,7 @@ export class TagsFormComponent implements OnInit {
   readonly tagStore = inject(TagStore);
   readonly dialog = inject(MatDialog);
   private destroyRef = inject(DestroyRef);
+  readonly detailStore = inject(DetailStore);
 
   tags = input.required<TagType[]>();
   inEditMode = input<boolean>(true);
@@ -132,5 +134,8 @@ export class TagsFormComponent implements OnInit {
 
   onCancel() {
     // TODO: This should reset the tags to their original?  Maybe store the original copy initially and rever to that?
+
+    // close the drawer
+    this.detailStore.clearDetailId();
   }
 }

--- a/packages/admin/src/app/styles/mixins/_config.scss
+++ b/packages/admin/src/app/styles/mixins/_config.scss
@@ -3,9 +3,10 @@
 @mixin config-theme($theme) {
   .config-bar-container {
     color: colors.$dark-blue;
+    margin-top: 5px;
 
     .config-bar-divider {
-      margin: 20px 0;
+      margin: 26px 0 20px;
       border-top: 2px solid colors.$primary-70;
     }
   }

--- a/packages/admin/src/app/styles/mixins/_form.scss
+++ b/packages/admin/src/app/styles/mixins/_form.scss
@@ -8,6 +8,13 @@
     width: 100%;
     margin: 0 auto;
 
+    .icons-container {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-bottom: 15px;
+    }
+
     .mat-form-field {
       width: 100%;
       margin-bottom: 16px;
@@ -17,7 +24,7 @@
       display: flex;
       justify-content: space-between;
       width: 100%;
-      margin-top: 16px;
+      margin: 16px 0;
     }
 
     .edit-button-container {

--- a/packages/admin/src/app/styles/mixins/_sidenav.scss
+++ b/packages/admin/src/app/styles/mixins/_sidenav.scss
@@ -31,7 +31,7 @@
     }
 
     .feature-accordion {
-      height: 89%;
+      height: 85%;
       display: flex;
       flex-direction: column;
       gap: $spacing;
@@ -120,7 +120,7 @@
   .route-content-container {
     height: 100%;
     width: 100%;
-    padding: 1em;
+    padding: 2em;
     overflow-y: auto;
     background-color: colors.$content-background;
   }

--- a/packages/admin/src/styles.scss
+++ b/packages/admin/src/styles.scss
@@ -53,6 +53,6 @@ a {
 
 .table-form-container {
   border-radius: layout.$card-border-radius;
-  padding: 32px;
+  padding: 16px;
   background-color: colors.$white;
 }


### PR DESCRIPTION
- did another styling pass on the admin application
- added list refresh functionality when updating tags on all objects and their types
- fixed issue where detail component was not updating when navigating from one object type to another (from tags then clicking on an event in the detail view for instance)
- added in toasts to tag saves
- added close drawer functionality when canceling adding tags (may want to review if this is the right behavior)