### PR TITLE
feature/ARCWELL-385/mplement hidden field on password forms for spam honey trap

### DIFF
--- a/packages/admin/src/app/feature/auth/forgot-password/forgot-password-form.component.html
+++ b/packages/admin/src/app/feature/auth/forgot-password/forgot-password-form.component.html
@@ -21,6 +21,16 @@
         <mat-icon matPrefix>mail</mat-icon>
       </mat-form-field>
 
+      <input
+        class="credential"
+        type="text"
+        matNativeControl
+        formControlName="credential"
+        type="text"
+        placeholder="credential"
+        tabindex="-1"
+      />
+
       <button
         mat-flat-button
         color="primary"

--- a/packages/admin/src/app/feature/auth/forgot-password/forgot-password-form.component.scss
+++ b/packages/admin/src/app/feature/auth/forgot-password/forgot-password-form.component.scss
@@ -1,0 +1,3 @@
+.credential {
+  visibility: hidden;
+}

--- a/packages/admin/src/app/feature/auth/forgot-password/forgot-password-form.component.ts
+++ b/packages/admin/src/app/feature/auth/forgot-password/forgot-password-form.component.ts
@@ -41,6 +41,8 @@ export class ForgotPasswordComponent implements OnInit {
 
   forgotForm = new FormGroup({
     email: new FormControl('', [Validators.email, Validators.required]),
+    // Honey pot trap
+    credential: new FormControl(null),
   });
 
   ngOnInit() {
@@ -51,11 +53,16 @@ export class ForgotPasswordComponent implements OnInit {
           (event as ControlEvent) instanceof FormSubmittedEvent &&
           this.forgotForm.controls.email.value
         ) {
-          this.authStore.forgotPassword(
-            this.forgotForm.controls.email.value,
-            location.origin,
-          );
-
+          // Do not submit form and call back end if honey pot field filled out
+          if (
+            !this.forgotForm.controls.credential.value &&
+            this.forgotForm.controls.credential.value !== ''
+          ) {
+            this.authStore.forgotPassword(
+              this.forgotForm.controls.email.value,
+              location.origin,
+            );
+          }
           this.router.navigate(['/']);
         }
       });

--- a/packages/admin/src/app/feature/auth/reset-password/reset-password-form.component.html
+++ b/packages/admin/src/app/feature/auth/reset-password/reset-password-form.component.html
@@ -35,6 +35,16 @@
     <mat-error>The two passwords must match.</mat-error>
   }
 
+  <input
+    class="credential"
+    type="text"
+    matNativeControl
+    formControlName="credential"
+    type="text"
+    placeholder="credential"
+    tabindex="-1"
+  />
+
   <button
     mat-stroked-button
     color="primary"

--- a/packages/admin/src/app/feature/auth/reset-password/reset-password-form.component.scss
+++ b/packages/admin/src/app/feature/auth/reset-password/reset-password-form.component.scss
@@ -11,3 +11,7 @@ mat-error {
 mat-spinner {
   margin: 1rem 0;
 }
+
+.credential {
+  visibility: hidden;
+}

--- a/packages/admin/src/app/feature/auth/reset-password/reset-password-form.component.ts
+++ b/packages/admin/src/app/feature/auth/reset-password/reset-password-form.component.ts
@@ -45,6 +45,8 @@ export class ResetPasswordComponent implements OnInit {
       code: new FormControl('', [Validators.required]),
       password: new FormControl('', [Validators.required]),
       confirmPassword: new FormControl('', [Validators.required]),
+      // Honey pot trap
+      credential: new FormControl(null),
     },
     { validators: InputMatch('password', 'confirmPassword') },
   );
@@ -60,11 +62,19 @@ export class ResetPasswordComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         if ((event as ControlEvent) instanceof FormSubmittedEvent) {
-          this.authStore.resetPassword(this.resetForm.value).then(() => {
-            if (this.authStore.loginStatus() !== 'error') {
-              this.router.navigate(['auth', 'login']);
-            }
-          });
+          // Do not submit form and call back end if honey pot field filled out
+          if (
+            !this.resetForm.controls.credential.value &&
+            this.resetForm.controls.credential.value !== ''
+          ) {
+            this.authStore.resetPassword(this.resetForm.value).then(() => {
+              if (this.authStore.loginStatus() !== 'error') {
+                this.router.navigate(['auth', 'login']);
+              }
+            });
+          } else {
+            this.router.navigate(['/']);
+          }
         }
       });
   }


### PR DESCRIPTION
- Add hidden input field on forgot and reset password forms as a honey pot for bots
- Do not submit form if form filled out/touched