### PR TITLE
fix/ARCWELL-434-tag-update-causing-transaction-to-hang

### DIFF
--- a/packages/server/app/controllers/tags_controller.ts
+++ b/packages/server/app/controllers/tags_controller.ts
@@ -215,7 +215,9 @@ export default class TagsController {
 
     return db.transaction(async (trx) => {
       const updatedTag = await TagService.updateTag(trx, params.id, cleanRequest)
-      return { data: this.tagQueryWithAllRelated(updatedTag.id, { limit: 10, offset: 0 }, trx) }
+      return {
+        data: await this.tagQueryWithAllRelated(updatedTag.id, { limit: 10, offset: 0 }, trx),
+      }
     })
   }
 


### PR DESCRIPTION
fix/ARCWELL-434-tag-update-causing-transaction-to-hang
- Tag update missing an await in return