### PR TITLE
fix/ARCWELL-456-fact-update-ignoring-attached-object-ids

### DIFF
--- a/packages/server/app/controllers/facts_controller.ts
+++ b/packages/server/app/controllers/facts_controller.ts
@@ -125,7 +125,14 @@ export default class FactsController {
     await request.validateUsing(updateFactValidator)
     await paramsUUIDValidator.validate(params)
 
-    const cleanRequest = request.only(['typeKey', 'observedAt', 'dimensions'])
+    const cleanRequest = request.only([
+      'typeKey',
+      'observedAt',
+      'dimensions',
+      'personId',
+      'resourceId',
+      'eventId',
+    ])
 
     if (cleanRequest.dimensions) {
       const factType = await FactType.query().where('key', cleanRequest.typeKey).firstOrFail()


### PR DESCRIPTION
fix/ARCWELL-456-fact-update-ignoring-attached-object-ids
- fact update will accept persionId, resourceId, and eventId