### PR TITLE
fix/ARCWELL-489/Correct bug on people search with the object selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sorting bug on Resources list
+- Bug when searching for a person to add to Event, Form, or Cohort
 
 ## [0.1.0] - 2024-10-21
 

--- a/packages/admin/src/app/shared/component-library/form/object-selector-form-field/object-selector-form-field.component.ts
+++ b/packages/admin/src/app/shared/component-library/form/object-selector-form-field/object-selector-form-field.component.ts
@@ -160,7 +160,7 @@ export class ObjectSelectorFormFieldComponent
           .getPeople({
             limit: 20,
             offset: 0,
-            search: [{ field: 'familyName', searchString: query }],
+            search: [{ field: 'family_name', searchString: query }],
             typeKey: this.typeKeySignal()['key'],
           })
           .subscribe(resp => {
@@ -183,7 +183,7 @@ export class ObjectSelectorFormFieldComponent
             limit: 20,
             offset: 0,
             notInCohort: this.objectIdForFiltering(),
-            search: [{ field: 'familyName', searchString: query }],
+            search: [{ field: 'family_name', searchString: query }],
             typeKey: this.typeKeySignal()['key'],
           })
           .subscribe(resp => {


### PR DESCRIPTION
- Make sure search object when searching for people has 'family_name' field in camel case